### PR TITLE
#11, Fix wrong captcha challenge image parsing

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
@@ -189,9 +189,6 @@ public class ChanSettings {
     public static final BooleanSetting reencodeHintShown;
 
     public static final BooleanSetting useNewCaptchaWindow;
-    public static final BooleanSetting useRealGoogleCookies;
-    public static final StringSetting googleCookie;
-    public static final LongSetting lastGoogleCookieUpdateTime;
 
     public static final OptionsSetting<PostingTimeout> postingTimeout;
 
@@ -290,9 +287,6 @@ public class ChanSettings {
         reencodeHintShown = new BooleanSetting(p, "preference_reencode_hint_already_shown", false);
 
         useNewCaptchaWindow = new BooleanSetting(p, "use_new_captcha_window", false);
-        useRealGoogleCookies = new BooleanSetting(p, "use_real_google_cookies", false);
-        googleCookie = new StringSetting(p, "google_cookie", "");
-        lastGoogleCookieUpdateTime = new LongSetting(p, "last_google_cookie_update_time", 0L);
     }
 
     public static ThemeColor getThemeAndColor() {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/v2/CaptchaNoJsHtmlParser.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/v2/CaptchaNoJsHtmlParser.java
@@ -372,8 +372,8 @@ public class CaptchaNoJsHtmlParser {
                 for (int row = 0; row < rows; ++row) {
                     Bitmap imagePiece = Bitmap.createBitmap(
                             originalBitmap,
-                            column * imageWidth,
-                            row * imageHeight,
+                            row * imageWidth,
+                            column * imageHeight,
                             imageWidth,
                             imageHeight);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/v2/CaptchaNoJsLayoutV2.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/v2/CaptchaNoJsLayoutV2.java
@@ -55,7 +55,6 @@ public class CaptchaNoJsLayoutV2 extends FrameLayout
     private AppCompatButton captchaVerifyButton;
     private AppCompatButton useOldCaptchaButton;
     private AppCompatButton reloadCaptchaButton;
-    private AppCompatButton refreshCookiesButton;
 
     private CaptchaNoJsV2Adapter adapter;
     private CaptchaNoJsPresenterV2 presenter;
@@ -89,7 +88,6 @@ public class CaptchaNoJsLayoutV2 extends FrameLayout
         captchaVerifyButton = view.findViewById(R.id.captcha_layout_v2_verify_button);
         useOldCaptchaButton = view.findViewById(R.id.captcha_layout_v2_use_old_captcha_button);
         reloadCaptchaButton = view.findViewById(R.id.captcha_layout_v2_reload_button);
-        refreshCookiesButton = view.findViewById(R.id.captcha_layout_v2_refresh_cookies);
         ConstraintLayout buttonsHolder = view.findViewById(R.id.captcha_layout_v2_buttons_holder);
         ScrollView background = view.findViewById(R.id.captcha_layout_v2_background);
 
@@ -100,16 +98,10 @@ public class CaptchaNoJsLayoutV2 extends FrameLayout
         captchaVerifyButton.setTextColor(AndroidUtils.getAttrColor(getContext(), R.attr.text_color_primary));
         useOldCaptchaButton.setTextColor(AndroidUtils.getAttrColor(getContext(), R.attr.text_color_primary));
         reloadCaptchaButton.setTextColor(AndroidUtils.getAttrColor(getContext(), R.attr.text_color_primary));
-        refreshCookiesButton.setTextColor(AndroidUtils.getAttrColor(getContext(), R.attr.text_color_primary));
 
         captchaVerifyButton.setOnClickListener(this);
         useOldCaptchaButton.setOnClickListener(this);
         reloadCaptchaButton.setOnClickListener(this);
-
-        if (ChanSettings.useRealGoogleCookies.get()) {
-            refreshCookiesButton.setVisibility(View.VISIBLE);
-            refreshCookiesButton.setOnClickListener(this);
-        }
 
         captchaVerifyButton.setEnabled(false);
     }
@@ -180,26 +172,6 @@ public class CaptchaNoJsLayoutV2 extends FrameLayout
         });
     }
 
-    @Override
-    public void onGoogleCookiesRefreshed() {
-        // called on a background thread
-
-        AndroidUtils.runOnUiThread(() -> {
-            showToast("Google cookies successfully refreshed");
-
-            // refresh the captcha as well
-            reset();
-        });
-    }
-
-    // Called when we could not get google cookies
-    @Override
-    public void onGetGoogleCookieError(boolean shouldFallback, Throwable error) {
-        // called on a background thread
-
-        handleError(shouldFallback, error);
-    }
-
     // Called when we got response from re-captcha but could not parse some part of it
     @Override
     public void onCaptchaInfoParseError(Throwable error) {
@@ -235,8 +207,6 @@ public class CaptchaNoJsLayoutV2 extends FrameLayout
             callback.onFallbackToV1CaptchaView();
         } else if (v == reloadCaptchaButton) {
             reset();
-        } else if (v == refreshCookiesButton) {
-            presenter.refreshCookies();
         }
     }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/BehaviourSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/BehaviourSettingsController.java
@@ -59,20 +59,7 @@ public class BehaviourSettingsController extends SettingsController {
     @Override
     public void onPreferenceChange(SettingView item) {
         super.onPreferenceChange(item);
-        if (item == useNewCaptchaWindow) {
-            // when user disables the new captcha window also disable the usage of the google cookies
-            if (!ChanSettings.useNewCaptchaWindow.get()) {
-                ChanSettings.useRealGoogleCookies.set(false);
-
-                // Reset the old google cookie
-                ChanSettings.googleCookie.set("");
-
-                // and cookie update time as well
-                ChanSettings.lastGoogleCookieUpdateTime.set(0L);
-            }
-
-            rebuildPreferences();
-        } else if (item == postingTimeoutSetting) {
+        if (item == postingTimeoutSetting) {
             Toast.makeText(context, R.string.setting_posting_timeout_toggle_notice,
                     Toast.LENGTH_LONG).show();
         }
@@ -177,13 +164,6 @@ public class BehaviourSettingsController extends SettingsController {
                     ChanSettings.useNewCaptchaWindow,
                     R.string.settings_use_new_captcha_window,
                     0));
-
-            if (ChanSettings.useNewCaptchaWindow.get()) {
-                captcha.add(new BooleanSettingView(this,
-                        ChanSettings.useRealGoogleCookies,
-                        R.string.settings_use_real_google_cookies,
-                        R.string.settings_use_real_google_cookies_description));
-            }
 
             groups.add(captcha);
         }

--- a/Kuroba/app/src/main/res/layout/layout_captcha_nojs_v2.xml
+++ b/Kuroba/app/src/main/res/layout/layout_captcha_nojs_v2.xml
@@ -55,25 +55,9 @@
                 android:text="@string/captcha_layout_v2_use_old_captcha"
                 android:textColor="#ffffff"
                 app:layout_constraintBottom_toBottomOf="@+id/captcha_layout_v2_verify_button"
-                app:layout_constraintEnd_toStartOf="@+id/captcha_layout_v2_refresh_cookies"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/captcha_layout_v2_verify_button" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/captcha_layout_v2_refresh_cookies"
-                android:layout_width="80dp"
-                android:layout_height="wrap_content"
-                android:background="?android:attr/selectableItemBackground"
-                android:clickable="true"
-                android:focusable="true"
-                android:text="@string/captcha_layout_v2_refresh_cookies"
-                android:textColor="#ffffff"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@+id/captcha_layout_v2_verify_button"
                 app:layout_constraintEnd_toStartOf="@+id/captcha_layout_v2_reload_button"
                 app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toEndOf="@+id/captcha_layout_v2_use_old_captcha_button"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/captcha_layout_v2_verify_button" />
 
             <androidx.appcompat.widget.AppCompatButton
@@ -88,7 +72,7 @@
                 app:layout_constraintBottom_toBottomOf="@+id/captcha_layout_v2_verify_button"
                 app:layout_constraintEnd_toStartOf="@+id/captcha_layout_v2_verify_button"
                 app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toEndOf="@+id/captcha_layout_v2_refresh_cookies"
+                app:layout_constraintStart_toEndOf="@+id/captcha_layout_v2_use_old_captcha_button"
                 app:layout_constraintTop_toTopOf="@+id/captcha_layout_v2_verify_button" />
 
             <androidx.appcompat.widget.AppCompatButton

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -625,7 +625,6 @@ Don't have a 4chan Pass?<br>
     <!-- Captcha settings -->
     <string name="settings_captcha_group">Captcha</string>
     <string name="settings_use_new_captcha_window">Use new captcha window for no-js captcha</string>
-    <string name="settings_use_real_google_cookies">Use real google cookies instead of hardcoded ones</string>
     <string name="settings_use_real_google_cookies_description">When enabled, a GET request to google.com will be executed to get a cookie, which will be used for captcha authentication. The hardcoded ones sometimes will make you re-enter the captcha dozens of times. Those cookies will be updated automatically (every three months). You may update them manually if you want.</string>
 
     <string name="captcha_layout_v2_verify_button_text">Verify</string>


### PR DESCRIPTION
Also, remove everything related to fetching google cookies because we don't need it anymore. New captcha works flawlessly with the hardcoded cookie.

Closes #11 

So basically the bug was in challenge's image parsing. I mixed up columns with rows and the image grid that was shown to the user was always rotated by 90 degrees to the left. Because of that the response was always wrong and recaptcha didn't accept it (but sometimes it did, and that's really strange).