### PR TITLE
(#206) Fix an "API parse error" when trying to open archived thread.

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/WatchManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/WatchManager.java
@@ -147,7 +147,7 @@ public class WatchManager implements WakeManager.Wakeable {
         this.wakeManager = wakeManager;
         this.pageRequestManager = pageRequestManager;
         this.threadSaveManager = threadSaveManager;
-        this.prevIncrementalThreadSavingEnabled = ChanSettings.watchEnabled.get() && ChanSettings.watchBackground.get();
+        this.prevIncrementalThreadSavingEnabled = false;
 
         databasePinManager = databaseManager.getDatabasePinManager();
         databaseSavedThreadManager = databaseManager.getDatabaseSavedThreadManager();

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedAppSettings.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedAppSettings.java
@@ -35,6 +35,8 @@ public class ExportedAppSettings {
     private List<ExportedFilter> exportedFilters;
     @SerializedName("exported_post_hides")
     private List<ExportedPostHide> exportedPostHides;
+    @SerializedName("exported_saved_threads")
+    private List<ExportedSavedThread> exportedSavedThreads;
     @SerializedName("exported_settings")
     @Nullable
     private String settings;
@@ -44,6 +46,7 @@ public class ExportedAppSettings {
             List<ExportedBoard> exportedBoards,
             List<ExportedFilter> exportedFilters,
             List<ExportedPostHide> exportedPostHides,
+            List<ExportedSavedThread> exportedSavedThreads,
             @NonNull
             String settings
     ) {
@@ -51,11 +54,13 @@ public class ExportedAppSettings {
         this.exportedBoards = exportedBoards;
         this.exportedFilters = exportedFilters;
         this.exportedPostHides = exportedPostHides;
+        this.exportedSavedThreads = exportedSavedThreads;
         this.settings = settings;
     }
 
     public static ExportedAppSettings empty() {
         return new ExportedAppSettings(
+                new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
                 new ArrayList<>(),
@@ -88,6 +93,10 @@ public class ExportedAppSettings {
         return exportedPostHides;
     }
 
+    public List<ExportedSavedThread> getExportedSavedThreads() {
+        return exportedSavedThreads;
+    }
+
     public int getVersion() {
         return CURRENT_EXPORT_SETTINGS_VERSION;
     }
@@ -111,6 +120,10 @@ public class ExportedAppSettings {
 
     public void setExportedPostHides(List<ExportedPostHide> exportedPostHides) {
         this.exportedPostHides = exportedPostHides;
+    }
+
+    public void setExportedSavedThreads(List<ExportedSavedThread> exportedSavedThreads) {
+        this.exportedSavedThreads = exportedSavedThreads;
     }
 
     public void setSettings(String settings) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedAppSettings.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedAppSettings.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.github.adamantcheese.chan.core.repository.ImportExportRepository.CURRENT_EXPORT_SETTINGS_VERSION;
@@ -94,7 +95,7 @@ public class ExportedAppSettings {
     }
 
     public List<ExportedSavedThread> getExportedSavedThreads() {
-        return exportedSavedThreads;
+        return exportedSavedThreads != null ? exportedSavedThreads : Collections.emptyList();
     }
 
     public int getVersion() {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedSavedThread.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedSavedThread.java
@@ -1,0 +1,41 @@
+package com.github.adamantcheese.chan.core.model.export;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ExportedSavedThread {
+    @SerializedName("loadable_id")
+    public int loadableId;
+    @SerializedName("last_saved_post_no")
+    public int lastSavedPostNo;
+    @SerializedName("is_fully_downloaded")
+    public boolean isFullyDownloaded;
+    @SerializedName("is_stopped")
+    public boolean isStopped;
+
+    public ExportedSavedThread(
+            int loadableId,
+            int lastSavedPostNo,
+            boolean isFullyDownloaded,
+            boolean isStopped) {
+        this.loadableId = loadableId;
+        this.lastSavedPostNo = lastSavedPostNo;
+        this.isFullyDownloaded = isFullyDownloaded;
+        this.isStopped = isStopped;
+    }
+
+    public int getLoadableId() {
+        return loadableId;
+    }
+
+    public int getLastSavedPostNo() {
+        return lastSavedPostNo;
+    }
+
+    public boolean isFullyDownloaded() {
+        return isFullyDownloaded;
+    }
+
+    public boolean isStopped() {
+        return isStopped;
+    }
+}

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/orm/Loadable.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/orm/Loadable.java
@@ -94,6 +94,7 @@ public class Loadable implements Cloneable {
     }
 
     public static Loadable importLoadable(
+            int loadableId,
             int siteId,
             int mode,
             String boardCode,
@@ -105,6 +106,7 @@ public class Loadable implements Cloneable {
             int lastLoaded
     ) {
         Loadable loadable = new Loadable();
+        loadable.id = loadableId;
         loadable.siteId = siteId;
         loadable.mode = mode;
         loadable.boardCode = boardCode;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/orm/SavedThread.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/orm/SavedThread.java
@@ -42,6 +42,10 @@ public class SavedThread {
         this(0, isFullyDownloaded, isStopped, 0, loadableId);
     }
 
+    public SavedThread(boolean isFullyDownloaded, boolean isStopped, int lastSavedPostNo, int loadableId) {
+        this(0, isFullyDownloaded, isStopped, lastSavedPostNo, loadableId);
+    }
+
     public SavedThread(int id, boolean isFullyDownloaded, boolean isStopped, int lastSavedPostNo, int loadableId) {
         this.id = id;
         this.isFullyDownloaded = isFullyDownloaded;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/DrawerController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/DrawerController.java
@@ -35,6 +35,7 @@ import com.github.adamantcheese.chan.core.manager.WatchManager;
 import com.github.adamantcheese.chan.core.manager.WatchManager.PinMessages;
 import com.github.adamantcheese.chan.core.model.orm.Pin;
 import com.github.adamantcheese.chan.core.model.orm.PinType;
+import com.github.adamantcheese.chan.core.model.orm.SavedThread;
 import com.github.adamantcheese.chan.core.settings.ChanSettings;
 import com.github.adamantcheese.chan.ui.adapter.DrawerAdapter;
 import com.github.adamantcheese.chan.utils.BackgroundUtils;
@@ -135,8 +136,12 @@ public class DrawerController extends Controller implements DrawerAdapter.Callba
 
         ThreadController threadController = getTopThreadController();
         if (threadController != null) {
-            // Try to load saved copy of a thread of pinned thread is archived or has an error flag
-            if (pin.archived || pin.isError) {
+            SavedThread savedThread = watchManager.findSavedThreadByLoadableId(pin.loadable.id);
+
+            // Try to load saved copy of a thread if pinned thread has an error flag but only if
+            // we are downloading this thread. Otherwise it will break archived threads that are not
+            // being downloaded
+            if (pin.isError && savedThread != null) {
                 pin.loadable.isSavedCopy = true;
             }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ViewThreadController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ViewThreadController.java
@@ -382,12 +382,16 @@ public class ViewThreadController extends ThreadController implements ThreadLayo
         super.onShowPosts(loadable);
 
         navigation.title = this.loadable.title;
-
         navigation.findItem(PIN_ID).setVisible(!loadable.isSavedCopy);
 
         ToolbarMenuItem saveThreadItem = navigation.findItem(SAVE_THREAD_ID);
         if (saveThreadItem != null) {
-            saveThreadItem.setVisible(!loadable.isSavedCopy);
+            Pin pin = watchManager.findPinByLoadableId(loadable.id);
+            if (pin != null && (pin.archived || pin.isError)) {
+                saveThreadItem.setVisible(false);
+            } else {
+                saveThreadItem.setVisible(!loadable.isSavedCopy);
+            }
         }
 
         ((ToolbarNavigationController) navigationController).toolbar.updateTitle(navigation);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadListLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadListLayout.java
@@ -77,6 +77,7 @@ import static com.github.adamantcheese.chan.utils.AndroidUtils.getDimen;
  * A layout that wraps around a {@link RecyclerView} and a {@link ReplyLayout} to manage showing and replying to posts.
  */
 public class ThreadListLayout extends FrameLayout implements ReplyLayout.ReplyLayoutCallback {
+    private static final String TAG = "ThreadListLayout";
     public static final int MAX_SMOOTH_SCROLL_DISTANCE = 20;
 
     private ReplyLayout reply;
@@ -132,7 +133,7 @@ public class ThreadListLayout extends FrameLayout implements ReplyLayout.ReplyLa
 
         postAdapter = new PostAdapter(recyclerView, postAdapterCallback, postCellCallback, statusCellCallback);
         recyclerView.setAdapter(postAdapter);
-        if(ChanSettings.shiftPostFormat.get()) {
+        if (ChanSettings.shiftPostFormat.get()) {
             recyclerView.getRecycledViewPool().setMaxRecycledViews(TYPE_POST, 0);
         }
         recyclerView.addOnScrollListener(scrollListener);

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -621,7 +621,7 @@ Don't have a 4chan Pass?<br>
     <string name="import_settings">Import settings</string>
     <string name="import_settings_from_a_file">Import settings from a file</string>
     <string name="import_warning_title">Warning</string>
-    <string name="import_warning_text">You are about to import settings/saved pins/filters/hidden posts from a file. The file must be located at \"%1$s\" and have a name \"%2$s\". This will clear all your existing settings/pins/threads and replace them with the ones from the file. You MAY LOOSE some of your settings/pins/hidden threads if you are trying to import a file with different app version (upgrade or downgrade). The app will be restarted. \nAre you sure you want to continue?</string>
+    <string name="import_warning_text">You are about to import settings/saved pins/filters/hidden posts from a file. The file must be located at \"%1$s\" and have a name \"%2$s\". This will clear all your existing settings/pins/threads and replace them with the ones from the file. You MAY LOSE some of your settings/pins/hidden threads if you are trying to import a file with different app version (upgrade or downgrade). The app will be restarted. \nAre you sure you want to continue?</string>
     <string name="successfully_exported_text">Exported successfully to \"%1$s\". File path has been copied to the clipboard"</string>
     <string name="error_external_storage_is_not_mounted">External storage is not mounted</string>
     <string name="could_not_create_dir_for_export_error_text">Could not create directory for export file %1$s; you probably won\'t be able to export settings</string>


### PR DESCRIPTION
Fix "download thread icon" is visible when entering an archived thread.
Fix endless attempt to download images that have been deleted from the server (404) while downloading a thread.
Make getFromDisk() method search an image in the cache first instead trying to find it on the disk.
Export/import information about downloaded/downloading threads. 
Fix loadable importing (was using wrong loadable id).

Closes #206, closes #213, Possible fix for #208, also should make image loading in the downloaded threads faster so might partially close #215 
