### PR TITLE
Fix importing of loadables and saved threads

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/database/DatabaseHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/database/DatabaseHelper.java
@@ -82,19 +82,35 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
     @Override
     public void onCreate(SQLiteDatabase database, ConnectionSource connectionSource) {
         try {
-            TableUtils.createTable(connectionSource, Pin.class);
-            TableUtils.createTable(connectionSource, Loadable.class);
-            TableUtils.createTable(connectionSource, SavedReply.class);
-            TableUtils.createTable(connectionSource, Board.class);
-            TableUtils.createTable(connectionSource, PostHide.class);
-            TableUtils.createTable(connectionSource, History.class);
-            TableUtils.createTable(connectionSource, Filter.class);
-            TableUtils.createTable(connectionSource, SiteModel.class);
-            TableUtils.createTable(connectionSource, SavedThread.class);
+            createTables(connectionSource);
         } catch (SQLException e) {
             Logger.e(TAG, "Error creating db", e);
             throw new RuntimeException(e);
         }
+    }
+
+    public void createTables(ConnectionSource connectionSource) throws SQLException {
+        TableUtils.createTable(connectionSource, Pin.class);
+        TableUtils.createTable(connectionSource, Loadable.class);
+        TableUtils.createTable(connectionSource, SavedReply.class);
+        TableUtils.createTable(connectionSource, Board.class);
+        TableUtils.createTable(connectionSource, PostHide.class);
+        TableUtils.createTable(connectionSource, History.class);
+        TableUtils.createTable(connectionSource, Filter.class);
+        TableUtils.createTable(connectionSource, SiteModel.class);
+        TableUtils.createTable(connectionSource, SavedThread.class);
+    }
+
+    public void dropTables(ConnectionSource connectionSource) throws SQLException {
+        TableUtils.dropTable(connectionSource, Pin.class, true);
+        TableUtils.dropTable(connectionSource, Loadable.class, true);
+        TableUtils.dropTable(connectionSource, SavedReply.class, true);
+        TableUtils.dropTable(connectionSource, Board.class, true);
+        TableUtils.dropTable(connectionSource, PostHide.class, true);
+        TableUtils.dropTable(connectionSource, History.class, true);
+        TableUtils.dropTable(connectionSource, Filter.class, true);
+        TableUtils.dropTable(connectionSource, SiteModel.class, true);
+        TableUtils.dropTable(connectionSource, SavedThread.class, true);
     }
 
     /**

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedLoadable.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedLoadable.java
@@ -21,6 +21,8 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Locale;
+
 public class ExportedLoadable {
     @SerializedName("board_code")
     private String boardCode;
@@ -108,5 +110,13 @@ public class ExportedLoadable {
     @Nullable
     public String getTitle() {
         return title;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return String.format(Locale.US,
+                "boardCode = %s, loadableId = %d, no = %d, mode= %d, siteId = %d, title = %s",
+                boardCode, loadableId, no, mode, siteId, title);
     }
 }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedSavedThread.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/export/ExportedSavedThread.java
@@ -1,6 +1,10 @@
 package com.github.adamantcheese.chan.core.model.export;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
+
+import java.util.Locale;
 
 public class ExportedSavedThread {
     @SerializedName("loadable_id")
@@ -37,5 +41,13 @@ public class ExportedSavedThread {
 
     public boolean isStopped() {
         return isStopped;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return String.format(Locale.US,
+                "loadableId: %d, lastSavedPostNo: %d, isFullyDownloaded: %b, isStopped: %b",
+                loadableId, lastSavedPostNo, isFullyDownloaded, isStopped);
     }
 }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/orm/Loadable.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/orm/Loadable.java
@@ -94,7 +94,6 @@ public class Loadable implements Cloneable {
     }
 
     public static Loadable importLoadable(
-            int loadableId,
             int siteId,
             int mode,
             String boardCode,
@@ -106,7 +105,6 @@ public class Loadable implements Cloneable {
             int lastLoaded
     ) {
         Loadable loadable = new Loadable();
-        loadable.id = loadableId;
         loadable.siteId = siteId;
         loadable.mode = mode;
         loadable.boardCode = boardCode;


### PR DESCRIPTION
Some threads were replaced by other threads in the pins list because of a bug in saved threads and loadables importing.
Settings re exporting shouldn't be required.