### PR TITLE
(#230) Disable unavoidable media scanner madness

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
@@ -62,6 +62,7 @@ public class ThreadSaveManager {
     public static final String SPOILER_FILE_NAME = "spoiler";
     public static final String THUMBNAIL_FILE_NAME = "thumbnail";
     public static final String ORIGINAL_FILE_NAME = "original";
+    public static final String NO_MEDIA_FILE_NAME = ".nomedia";
 
     private DatabaseManager databaseManager;
     private DatabaseSavedThreadManager databaseSavedThreadManager;
@@ -328,6 +329,19 @@ public class ThreadSaveManager {
             File threadSaveDirImages = new File(threadSaveDir, IMAGES_DIR_NAME);
             if (!threadSaveDirImages.exists() && !threadSaveDirImages.mkdirs()) {
                 throw new CouldNotCreateImagesDirectoryException(threadSaveDirImages);
+            }
+
+            if (ChanSettings.allowMediaScannerToScanLocalThreads.get()) {
+                File noMediaFile = new File(threadSaveDirImages, NO_MEDIA_FILE_NAME);
+                if (!noMediaFile.exists() && !noMediaFile.createNewFile()) {
+                    throw new CouldNotCreateNoMediaFile(threadSaveDirImages);
+                }
+            } else {
+                File noMediaFile = new File(threadSaveDirImages, NO_MEDIA_FILE_NAME);
+                if (noMediaFile.exists() && !noMediaFile.delete()) {
+                    Logger.e(TAG, "Could not delete .nomedia file from directory "
+                            + threadSaveDirImages.getAbsolutePath());
+                }
             }
 
             // Filter out already saved posts and sort new posts in ascending order
@@ -1129,6 +1143,12 @@ public class ThreadSaveManager {
         public CouldNotCreateThreadDirectoryException(File threadSaveDir) {
             super("Could not create a directory to save the thread " +
                     "to (full path: " + threadSaveDir.getAbsolutePath() + ")");
+        }
+    }
+
+    class CouldNotCreateNoMediaFile extends Exception {
+        public CouldNotCreateNoMediaFile(File threadSaveDirImages) {
+            super("Could not create .nomedia file in directory " + threadSaveDirImages.getAbsolutePath());
         }
     }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
@@ -332,6 +332,8 @@ public class ThreadSaveManager {
             }
 
             if (ChanSettings.allowMediaScannerToScanLocalThreads.get()) {
+                // .nomedia file being in the images directory "should" prevent media scanner to scan
+                // this directory
                 File noMediaFile = new File(threadSaveDirImages, NO_MEDIA_FILE_NAME);
                 if (!noMediaFile.exists() && !noMediaFile.createNewFile()) {
                     throw new CouldNotCreateNoMediaFile(threadSaveDirImages);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
@@ -332,8 +332,8 @@ public class ThreadSaveManager {
             }
 
             if (ChanSettings.allowMediaScannerToScanLocalThreads.get()) {
-                // .nomedia file being in the images directory "should" prevent media scanner to scan
-                // this directory
+                // .nomedia file being in the images directory "should" prevent media scanner from
+                // scanning this directory
                 File noMediaFile = new File(threadSaveDirImages, NO_MEDIA_FILE_NAME);
                 if (!noMediaFile.exists() && !noMediaFile.createNewFile()) {
                     throw new CouldNotCreateNoMediaFile(threadSaveDirImages);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
@@ -144,6 +144,7 @@ public class ChanSettings {
     public static final BooleanSetting videoDefaultMuted;
     public static final BooleanSetting videoAutoLoop;
     public static final BooleanSetting autoLoadThreadImages;
+    public static final BooleanSetting allowMediaScannerToScanLocalThreads;
 
     public static final BooleanSetting watchEnabled;
     public static final BooleanSetting watchBackground;
@@ -230,6 +231,7 @@ public class ChanSettings {
         videoDefaultMuted = new BooleanSetting(p, "preference_video_default_muted", true);
         videoAutoLoop = new BooleanSetting(p, "preference_video_loop", true);
         autoLoadThreadImages = new BooleanSetting(p, "preference_auto_load_thread", false);
+        allowMediaScannerToScanLocalThreads = new BooleanSetting(p, "allow_media_scanner_to_scan_local_threads", false);
 
         watchEnabled = new BooleanSetting(p, "preference_watch_enabled", false);
         watchEnabled.addCallback((setting, value) ->

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/MediaSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/MediaSettingsController.java
@@ -130,6 +130,11 @@ public class MediaSettingsController extends SettingsController {
                     R.string.settings_reveal_image_spoilers,
                     R.string.settings_reveal_image_spoilers_description));
 
+            media.add(new BooleanSettingView(this,
+                    ChanSettings.allowMediaScannerToScanLocalThreads,
+                    R.string.settings_allow_media_scanner_scan_local_threads_title,
+                    R.string.settings_allow_media_scanner_scan_local_threads_description));
+
             groups.add(media);
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/IOUtils.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/IOUtils.java
@@ -122,8 +122,11 @@ public class IOUtils {
 
     public static void deleteDirWithContents(File dir) {
         if (dir.isDirectory()) {
-            for (File c : dir.listFiles()) {
-                deleteDirWithContents(c);
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File c : files) {
+                    deleteDirWithContents(c);
+                }
             }
         }
 

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -693,4 +693,6 @@ Don't have a 4chan Pass?<br>
     <string name="settings_experimental_settings_description">These settings may be in an unstable state. They are for testing. They may break the app and you may have to reset the app data. Use them at your own risk if you are really interested in some feature. Backup your everything beforehand.</string>
     <string name="incremental_thread_downloading_title">Incremental thread downloading</string>
     <string name="incremental_thread_downloading_description">Allows you to download threads to view them after the original thread dies</string>
+    <string name="settings_allow_media_scanner_scan_local_threads_title">Allow Android media scanner to scan images from local saved threads</string>
+    <string name="settings_allow_media_scanner_scan_local_threads_description">If enabled, images that were downloaded along with threads will appear in other applications, like galleries, messengers etc. When changing this setting you may have to restart your phone or wait a little bit for the changes to kick in</string>
 </resources>


### PR DESCRIPTION
Add an option to enable it, but by default this behavior is disabled.

Closes #230 