### PR TITLE
(#304) Pass WatchManager to ChanLoader via constructor instead of cre…

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/FilterWatchManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/FilterWatchManager.java
@@ -132,7 +132,10 @@ public class FilterWatchManager implements WakeManager.Wakeable {
                         BackgroundLoader backgroundLoader = new BackgroundLoader();
                         Loadable boardLoadable = Loadable.forCatalog(b);
                         boardLoadable = databaseLoadableManager.get(boardLoadable);
-                        ChanThreadLoader catalogLoader = chanLoaderFactory.obtain(boardLoadable, backgroundLoader);
+                        ChanThreadLoader catalogLoader = chanLoaderFactory.obtain(
+                                boardLoadable,
+                                watchManager,
+                                backgroundLoader);
                         filterLoaders.put(catalogLoader, backgroundLoader);
                     }
             }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/WatchManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/WatchManager.java
@@ -631,7 +631,7 @@ public class WatchManager implements WakeManager.Wakeable {
 
     private boolean createPinWatcher(Pin pin) {
         if (!pinWatchers.containsKey(pin)) {
-            pinWatchers.put(pin, new PinWatcher(pin));
+            pinWatchers.put(pin, new PinWatcher(pin, this));
             return true;
         } else {
             return false;
@@ -1004,11 +1004,11 @@ public class WatchManager implements WakeManager.Wakeable {
         public int lastReplyCount = -1;
         public int latestKnownPage = -1;
 
-        public PinWatcher(Pin pin) {
+        public PinWatcher(Pin pin, WatchManager watchManager) {
             this.pin = pin;
 
             Logger.d(TAG, "created for " + pin.loadable.toString());
-            chanLoader = chanLoaderFactory.obtain(pin.loadable, this);
+            chanLoader = chanLoaderFactory.obtain(pin.loadable, watchManager, this);
             pageRequestManager.addListener(this);
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/pool/ChanLoaderFactory.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/pool/ChanLoaderFactory.java
@@ -33,7 +33,7 @@ import static com.github.adamantcheese.chan.Chan.inject;
 /**
  * ChanLoaderFactory is a factory for ChanLoaders. ChanLoaders for threads are cached.
  * <p>Each reference to a loader is a {@link ChanThreadLoader.ChanLoaderCallback}, these
- * references can be obtained with {@link #obtain(Loadable, ChanThreadLoader.ChanLoaderCallback)}} and released
+ * references can be obtained with {@link #obtain(Loadable, WatchManager, ChanThreadLoader.ChanLoaderCallback)}} and released
  * with {@link #release(ChanThreadLoader, ChanThreadLoader.ChanLoaderCallback)}.
  */
 public class ChanLoaderFactory {
@@ -43,7 +43,7 @@ public class ChanLoaderFactory {
     private Map<Loadable, ChanThreadLoader> threadLoaders = new HashMap<>();
     private LruCache<Loadable, ChanThreadLoader> threadLoadersCache = new LruCache<>(THREAD_LOADERS_CACHE_SIZE);
 
-    public ChanThreadLoader obtain(Loadable loadable, ChanThreadLoader.ChanLoaderCallback listener) {
+    public ChanThreadLoader obtain(Loadable loadable, WatchManager watchManager, ChanThreadLoader.ChanLoaderCallback listener) {
         ChanThreadLoader chanLoader;
         if (loadable.isThreadMode()) {
             if (!loadable.isFromDatabase()) {
@@ -60,11 +60,11 @@ public class ChanLoaderFactory {
             }
 
             if (chanLoader == null) {
-                chanLoader = new ChanThreadLoader(loadable);
+                chanLoader = new ChanThreadLoader(loadable, watchManager);
                 threadLoaders.put(loadable, chanLoader);
             }
         } else {
-            chanLoader = new ChanThreadLoader(loadable);
+            chanLoader = new ChanThreadLoader(loadable, watchManager);
         }
 
         chanLoader.addListener(listener);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -167,7 +167,7 @@ public class ThreadPresenter implements ChanThreadLoader.ChanLoaderCallback,
             this.addToLocalBackHistory = addToLocalBackHistory;
 
             startSavingThreadIfItIsNotBeingSaved(this.loadable);
-            chanLoader = chanLoaderFactory.obtain(loadable, this);
+            chanLoader = chanLoaderFactory.obtain(loadable, watchManager, this);
             threadPresenterCallback.showLoading();
         }
     }


### PR DESCRIPTION
…ating it inside of the ChanLoader to avoid cyclic dependency instantiation

Fixes slow app load time.

Closes #304 