### PR TITLE
Update Studio and Okhttp

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -138,7 +138,7 @@ dependencies {
 
     implementation 'com.google.android.exoplayer:exoplayer:2.10.1'
 
-    implementation 'com.squareup.okhttp3:okhttp:3.14.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.2'
     implementation 'com.j256.ormlite:ormlite-core:5.1'
     implementation 'com.j256.ormlite:ormlite-android:5.1'
     implementation 'org.jsoup:jsoup:1.11.3'

--- a/Kuroba/build.gradle
+++ b/Kuroba/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 


### PR DESCRIPTION
Release notes for Android Studio 3.5.0: https://developer.android.com/studio/releases#3-5-0

Release notes for Okhttp 3.14.2: https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-3142

#### Other dependencies that can be updated (in case you don't already know):

- Flexmark 0.50.22 -> 0.50.28 (https://github.com/vsch/flexmark-java/blob/master/VERSION.md)
- Okhttp 3.x -> 4.x (https://square.github.io/okhttp/upgrading_to_okhttp_4/)
- Jsoup 1.11.3 -> 1.12.1 (https://github.com/jhy/jsoup/blob/master/CHANGES)
- RxJava 2.2.9 -> 2.2.12 (https://github.com/ReactiveX/RxJava/releases)
- ExoPlayer 2.10.1 -> 2.10.4 (https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md)
- Fuzzywuzzy 1.1.10 -> 1.2.0 (https://github.com/xdrop/fuzzywuzzy/releases)
- Android-gif-drawable 1.2.12 -> 1.2.17 (https://github.com/koral--/android-gif-drawable/releases) (for whatever reason there are breaking changes here that aren't stated anywhere)
