### PR TITLE
(#397) wrong sub dirs and file names filtering

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/image/ImageLoaderV2.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/image/ImageLoaderV2.java
@@ -58,13 +58,13 @@ public class ImageLoaderV2 {
             String formattedName;
 
             if (postImage.spoiler) {
-                String extension = StringUtils.extractFileExtensionFromImageUrl(
+                String extension = StringUtils.extractFileNameExtension(
                         postImage.spoilerThumbnailUrl.toString());
 
                 formattedName = ThreadSaveManager.formatSpoilerImageName(extension);
             } else {
                 if (isThumbnail) {
-                    String extension = StringUtils.extractFileExtensionFromImageUrl(
+                    String extension = StringUtils.extractFileNameExtension(
                             postImage.thumbnailUrl.toString());
 
                     if (extension == null) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
@@ -747,7 +747,7 @@ public class ThreadSaveManager {
             }
 
             {
-                String thumbnailExtension = StringUtils.extractFileExtensionFromImageUrl(
+                String thumbnailExtension = StringUtils.extractFileNameExtension(
                         postImage.thumbnailUrl.toString());
                 String thumbnailImageFilename = postImage.serverFilename + "_"
                         + THUMBNAIL_FILE_NAME + "." + thumbnailExtension;
@@ -794,7 +794,7 @@ public class ThreadSaveManager {
     ) throws IOException {
         // If the board uses spoiler image - download it
         if (loadable.board.spoilers && spoilerImageUrl != null) {
-            String spoilerImageExtension = StringUtils.extractFileExtensionFromImageUrl(
+            String spoilerImageExtension = StringUtils.extractFileNameExtension(
                     spoilerImageUrl.toString());
             if (spoilerImageExtension == null) {
                 Logger.e(TAG, "Could not extract spoiler image extension from url, spoilerImageUrl = "
@@ -872,7 +872,7 @@ public class ThreadSaveManager {
                             return Single.just(false);
                         }
 
-                        String thumbnailExtension = StringUtils.extractFileExtensionFromImageUrl(
+                        String thumbnailExtension = StringUtils.extractFileNameExtension(
                                 postImage.thumbnailUrl.toString());
 
                         if (thumbnailExtension == null) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
@@ -267,9 +267,9 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
     /**
      * @param isFileName is used to figure out what characters are allowed and what are not.
      *                   If set to false, then we additionally remove all '.' characters because
-     *                   directory name should have '.' characters (well it actually can but let's
-     *                   filter them anyway). If it's false then it is implied that the "name" param
-     *                   is a directory segment name.
+     *                   directory names should not have '.' characters (well they actually can but
+     *                   let's filter them anyway). If it's false then it is implied that the "name"
+     *                   param is a directory segment name.
      * */
     private String filterName(String name, boolean isFileName) {
         String filteredName;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
@@ -43,7 +43,6 @@ import org.greenrobot.eventbus.Subscribe;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Pattern;
 
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getAppContext;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getString;
@@ -51,7 +50,6 @@ import static com.github.adamantcheese.chan.utils.AndroidUtils.getString;
 public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
     private static final String TAG = "ImageSaver";
     private static final int MAX_NAME_LENGTH = 50;
-    private static final Pattern UNSAFE_CHARACTERS_PATTERN = Pattern.compile("[^a-zA-Z0-9._\\\\ -]");
 
     private FileManager fileManager;
     private ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -123,7 +121,7 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
     }
 
     public String getSubFolder(String name) {
-        String filtered = filterDirName(name);
+        String filtered = filterName(name, false);
         filtered = filtered.substring(0, Math.min(filtered.length(), MAX_NAME_LENGTH));
         return filtered;
     }
@@ -266,20 +264,46 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
         return text;
     }
 
-    private String filterDirName(String name) {
-        name = StringUtils.dirNameRemoveBadCharacters(name);
-        if (name.length() == 0) {
-            name = "_";
-        }
-        return name;
-    }
+    /**
+     * @param isFileName is used to figure out what characters are allowed and what are not.
+     *                   If set to false, then we additionally remove all '.' characters because
+     *                   directory name should have '.' characters (well it actually can but let's
+     *                   filter them anyway). If it's false then it is implied that the "name" param
+     *                   is a directory segment name.
+     * */
+    private String filterName(String name, boolean isFileName) {
+        String filteredName;
 
-    private String filterFileName(String name) {
-        name = UNSAFE_CHARACTERS_PATTERN.matcher(name).replaceAll("");
-        if (name.length() == 0) {
-            name = "_";
+        if (isFileName) {
+            filteredName = StringUtils.fileNameRemoveBadCharacters(name);
+        } else {
+            filteredName = StringUtils.dirNameRemoveBadCharacters(name);
         }
-        return name;
+
+        String extension = StringUtils.extractFileNameExtension(filteredName);
+
+        // Remove the extension length + the '.' symbol from the resulting "filteredName" length
+        // and if it equals to 0 that means that the whole file name consists of bad characters
+        // (e.g. the whole filename consists of japanese characters) so we need to generate a new
+        // file name
+        boolean isOnlyExtensionLeft
+                = (extension != null && (filteredName.length() - extension.length() - 1) == 0);
+
+        // filteredName.length() == 0 will only be true when "name" parameter not have an extension
+        if (filteredName.length() == 0 || isOnlyExtensionLeft) {
+            String appendExtension;
+
+            if (extension != null) {
+                // extractFileNameExtension returns an extension without the '.' symbol
+                appendExtension = "." + extension;
+            } else {
+                appendExtension = "";
+            }
+
+            filteredName = System.currentTimeMillis() + appendExtension;
+        }
+
+        return filteredName;
     }
 
     @Nullable
@@ -288,7 +312,7 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
                 ? postImage.serverFilename
                 : postImage.filename;
 
-        String fileName = filterFileName(name + "." + postImage.extension);
+        String fileName = filterName(name + "." + postImage.extension, true);
 
         AbstractFile saveLocation = getSaveLocation(task);
         if (saveLocation == null) {
@@ -304,7 +328,7 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
                     Long.toString(SystemClock.elapsedRealtimeNanos(), Character.MAX_RADIX)
                     + "." + postImage.extension;
 
-            fileName = filterFileName(resultFileName);
+            fileName = filterName(resultFileName, true);
             saveFile = saveLocation
                     .clone(new FileSegment(fileName));
         }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
@@ -289,7 +289,8 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
         boolean isOnlyExtensionLeft
                 = (extension != null && (filteredName.length() - extension.length() - 1) == 0);
 
-        // filteredName.length() == 0 will only be true when "name" parameter not have an extension
+        // filteredName.length() == 0 will only be true when "name" parameter does not have an
+        // extension
         if (filteredName.length() == 0 || isOnlyExtensionLeft) {
             String appendExtension;
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaver.java
@@ -32,6 +32,7 @@ import com.github.adamantcheese.chan.ui.helper.RuntimePermissionsHelper;
 import com.github.adamantcheese.chan.ui.service.SavingNotification;
 import com.github.adamantcheese.chan.ui.settings.base_directory.SavedFilesBaseDirectory;
 import com.github.adamantcheese.chan.utils.Logger;
+import com.github.adamantcheese.chan.utils.StringUtils;
 import com.github.k1rakishou.fsaf.FileManager;
 import com.github.k1rakishou.fsaf.file.AbstractFile;
 import com.github.k1rakishou.fsaf.file.FileSegment;
@@ -122,7 +123,7 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
     }
 
     public String getSubFolder(String name) {
-        String filtered = filterName(name);
+        String filtered = filterDirName(name);
         filtered = filtered.substring(0, Math.min(filtered.length(), MAX_NAME_LENGTH));
         return filtered;
     }
@@ -265,7 +266,15 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
         return text;
     }
 
-    private String filterName(String name) {
+    private String filterDirName(String name) {
+        name = StringUtils.dirNameRemoveBadCharacters(name);
+        if (name.length() == 0) {
+            name = "_";
+        }
+        return name;
+    }
+
+    private String filterFileName(String name) {
         name = UNSAFE_CHARACTERS_PATTERN.matcher(name).replaceAll("");
         if (name.length() == 0) {
             name = "_";
@@ -279,7 +288,7 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
                 ? postImage.serverFilename
                 : postImage.filename;
 
-        String fileName = filterName(name + "." + postImage.extension);
+        String fileName = filterFileName(name + "." + postImage.extension);
 
         AbstractFile saveLocation = getSaveLocation(task);
         if (saveLocation == null) {
@@ -295,7 +304,7 @@ public class ImageSaver implements ImageSaveTask.ImageSaveTaskCallback {
                     Long.toString(SystemClock.elapsedRealtimeNanos(), Character.MAX_RADIX)
                     + "." + postImage.extension;
 
-            fileName = filterName(resultFileName);
+            fileName = filterFileName(resultFileName);
             saveFile = saveLocation
                     .clone(new FileSegment(fileName));
         }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/PostImageThumbnailView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/PostImageThumbnailView.java
@@ -67,12 +67,12 @@ public class PostImageThumbnailView extends ThumbnailView implements View.OnLong
                     String fileName;
 
                     if (postImage.spoiler) {
-                        String extension = StringUtils.extractFileExtensionFromImageUrl(
+                        String extension = StringUtils.extractFileNameExtension(
                                 postImage.spoilerThumbnailUrl.toString());
 
                         fileName = ThreadSaveManager.formatSpoilerImageName(extension);
                     } else {
-                        String extension = StringUtils.extractFileExtensionFromImageUrl(
+                        String extension = StringUtils.extractFileNameExtension(
                                 postImage.thumbnailUrl.toString());
 
                         fileName = ThreadSaveManager.formatThumbnailImageName(

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/StringUtils.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/StringUtils.java
@@ -30,20 +30,20 @@ public class StringUtils {
     }
 
     @Nullable
-    public static String extractFileExtensionFromImageUrl(String url) {
-        int index = url.lastIndexOf('.');
+    public static String extractFileNameExtension(String filename) {
+        int index = filename.lastIndexOf('.');
         if (index == -1) {
             return null;
         }
 
-        return url.substring(index + 1);
+        return filename.substring(index + 1);
     }
 
     public static String dirNameRemoveBadCharacters(String dirName) {
         return dirName
                 .toLowerCase()
                 .replaceAll(" ", "_")
-                .replaceAll("[^a-z0-9_]", "");
+                .replaceAll("[^a-z0-9_-]", "");
     }
 
     /**
@@ -53,6 +53,6 @@ public class StringUtils {
         return filename
                 .toLowerCase()
                 .replaceAll(" ", "_")
-                .replaceAll("[^a-z0-9_.]", "");
+                .replaceAll("[^a-z0-9_.-]", "");
     }
 }


### PR DESCRIPTION
When a thread title contains dots  or spaces (Filter dots in sub directory path segments (they shouldn't contain dots) and leave them as is in file names and spaces in both). SAF will crash with IllegalStateException if you try to pass into it a path containing spaces (that's why it encodes them with %20).

The inner Kuroba directory is not created anymore (I didn't change anything but I can't reproduce it anymore)

Closes #397