### PR TITLE
(#395) Introduce leak-canary.

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -226,6 +226,7 @@ dependencies {
     implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha'
 
     testImplementation 'junit:junit:4.12'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-beta-3'
 }
 
 //========================================================

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/StartActivity.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/StartActivity.java
@@ -122,7 +122,6 @@ public class StartActivity
         Chan.injector().instance(ThemeHelper.class).setupContext(this);
 
         fileChooser.setCallbacks(this);
-
         imagePickDelegate = new ImagePickDelegate(this);
         runtimePermissionsHelper = new RuntimePermissionsHelper(this);
         updateManager = new UpdateManager(this);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
@@ -149,7 +149,18 @@ public class ReplyLayout extends LoadView implements
 
     public ReplyLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
         EventBus.getDefault().register(this);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        EventBus.getDefault().unregister(this);
     }
 
     @Override


### PR DESCRIPTION
Also, fix a memory leak in ReplyLayout (EventBus was not unregistred upon view death)

Closes #395 

This thing is only turned on for dev builds! It won't even be compiled into the release build.
How to  use this shit:
It's best to use it with "Don't keep activities" dev option.
You just use the app normally and when you notice this icon 
![image](https://user-images.githubusercontent.com/10332458/68069925-2cbd0a00-fd78-11e9-894a-42932bae7abd.png)
Just click the notification and it will start doing it's job. Then after it's done click the notification again and the "Leaks" application will be opened with all the registered memory leaks. 
![image](https://user-images.githubusercontent.com/10332458/68069941-6ee64b80-fd78-11e9-95ce-521800773030.png)
Just report anything there is as a new issue.
![image](https://user-images.githubusercontent.com/10332458/68069986-fd5acd00-fd78-11e9-81a8-a8b8146fdc03.png)
![image](https://user-images.githubusercontent.com/10332458/68069972-d8665a00-fd78-11e9-9ef3-eea1387099c1.png)
