### PR TITLE
(#437) Another attempt to fix leak in browser controller

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/StartActivity.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/StartActivity.java
@@ -549,9 +549,13 @@ public class StartActivity
 
         fileChooser.removeCallbacks();
 
-        // TODO: clear whole stack?
-        stackTop().onHide();
-        stackTop().onDestroy();
+        for (int i = stack.size() - 1; i >= 0; --i) {
+            Controller controller = stack.get(i);
+
+            controller.onHide();
+            controller.onDestroy();
+        }
+
         stack.clear();
     }
 


### PR DESCRIPTION
The reason of the memory leak was that we only called onDestroy() for the top-most controller in the controller stack instead of calling it for every controller in the stack.

Closes #437 this time for sure.