### PR TITLE
(#459) Fix posts/threads not hiding until manual UI refresh

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -462,7 +462,7 @@ public class ThreadPresenter
 
     public void refreshUI() {
         if (chanLoader != null && chanLoader.getThread() != null) {
-            showPosts();
+            showPosts(true);
         }
     }
 
@@ -1215,8 +1215,16 @@ public class ThreadPresenter
     }
 
     private void showPosts() {
+        showPosts(false);
+    }
+
+    private void showPosts(boolean refreshAfterHideOrRemovePosts) {
         if (chanLoader != null && chanLoader.getThread() != null) {
-            threadPresenterCallback.showPosts(chanLoader.getThread(), new PostsFilter(order, searchQuery));
+            threadPresenterCallback.showPosts(
+                    chanLoader.getThread(),
+                    new PostsFilter(order, searchQuery),
+                    refreshAfterHideOrRemovePosts
+            );
         }
     }
 
@@ -1318,7 +1326,7 @@ public class ThreadPresenter
     }
 
     public interface ThreadPresenterCallback {
-        void showPosts(ChanThread thread, PostsFilter filter);
+        void showPosts(ChanThread thread, PostsFilter filter, boolean refreshAfterHideOrRemovePosts);
 
         void postClicked(Post post);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/PostAdapter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/PostAdapter.java
@@ -213,7 +213,7 @@ public class PostAdapter
         }
     }
 
-    public void setThread(Loadable threadLoadable, List<Post> posts) {
+    public void setThread(Loadable threadLoadable, List<Post> posts, boolean refreshAfterHideOrRemovePosts) {
         BackgroundUtils.ensureMainThread();
         boolean changed = this.loadable != null && !this.loadable.equals(threadLoadable); //changed threads, update
 
@@ -249,7 +249,13 @@ public class PostAdapter
 
         //update for indicator (adds/removes extra recycler item that causes inconsistency exceptions)
         //or if something changed per reasons above
-        if (lastLastSeenIndicator != lastSeenIndicatorPosition || changed) {
+        if (
+                lastLastSeenIndicator != lastSeenIndicatorPosition
+                        || changed
+                        // When true that means that the user has just hid or removed post/thread
+                        // so we need to refresh the UI
+                        || refreshAfterHideOrRemovePosts
+        ) {
             notifyDataSetChanged();
         }
     }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
@@ -256,7 +256,7 @@ public class ThreadLayout
     }
 
     @Override
-    public void showPosts(ChanThread thread, PostsFilter filter) {
+    public void showPosts(ChanThread thread, PostsFilter filter, boolean refreshAfterHideOrRemovePosts) {
         if (thread.getLoadable().isLocal()) {
             if (replyButton.getVisibility() == VISIBLE) {
                 replyButton.hide();
@@ -269,7 +269,13 @@ public class ThreadLayout
 
         getPresenter().updateLoadable(thread.getLoadable().loadableDownloadingState);
 
-        threadListLayout.showPosts(thread, filter, visible != Visible.THREAD);
+        threadListLayout.showPosts(
+                thread,
+                filter,
+                visible != Visible.THREAD,
+                refreshAfterHideOrRemovePosts
+        );
+
         switchVisible(Visible.THREAD);
         callback.onShowPosts();
     }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadListLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadListLayout.java
@@ -271,7 +271,12 @@ public class ThreadListLayout
         }
     }
 
-    public void showPosts(ChanThread thread, PostsFilter filter, boolean initial) {
+    public void showPosts(
+            ChanThread thread,
+            PostsFilter filter,
+            boolean initial,
+            boolean refreshAfterHideOrRemovePosts
+    ) {
         showingThread = thread;
         if (initial) {
             reply.bindLoadable(showingThread.getLoadable());
@@ -330,7 +335,7 @@ public class ThreadListLayout
             filteredPosts.removeAll(toRemove);
         }
 
-        postAdapter.setThread(thread.getLoadable(), filteredPosts);
+        postAdapter.setThread(thread.getLoadable(), filteredPosts, refreshAfterHideOrRemovePosts);
     }
 
     public boolean onBack() {


### PR DESCRIPTION
Closes #459

Fix a bug where a post/thread couldn't be hidden manually due to how we now check whether we should update the RecyclerView with posts or not