### PR TITLE
(#482) targetsdk 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ android:
     - platform-tools
     - tools
     - extra-android-m2repository
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-29.0.2
+    - android-29
 install:
   - sudo apt-get update
   - sudo apt-get install python3

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -8,7 +8,7 @@ android {
     // don't forget to also update travis.yml config
     // !!! IMPORTANT !!!
 
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     def getCommitHash = { ->
         def stdout = new ByteArrayOutputStream()
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
 
         /**
          * ------------------------------------------------------------

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
@@ -133,9 +133,10 @@ public class ThreadSaveManager {
         // Just buffer everything in the internal queue when the consumers are slow (and they are
         // always slow because they have to download images, but we check whether a download request
         // is already enqueued so it's okay for us to rely on the buffering)
-        workerQueue.onBackpressureBuffer()
+        workerQueue
                 // Collect all the request over some time
                 .buffer(REQUEST_BUFFERING_TIME_SECONDS, SECONDS)
+                .onBackpressureBuffer()
                 .concatMap(this::processCollectedRequests)
                 .subscribe(res -> {},
                         // OK


### PR DESCRIPTION
Closes #482

Didn't really have any problems with it so I assume it's safe to use v29.