### PR TITLE
(#498) Check whether the attached file exists before trying to apply …

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageReencodingPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageReencodingPresenter.java
@@ -99,6 +99,10 @@ public class ImageReencodingPresenter {
         );
     }
 
+    public boolean hasAttachedFile() {
+        return replyManager.getReply(loadable).file != null;
+    }
+
     @Nullable
     public Bitmap.CompressFormat getImageFormat() {
         try {
@@ -345,6 +349,11 @@ public class ImageReencodingPresenter {
 
         public String prettyPrint(Bitmap.CompressFormat currentFormat) {
             String type = "Unknown";
+            if (currentFormat == null) {
+                Logger.e(TAG, "currentFormat == null");
+                return type;
+            }
+
             switch (reencodeType) {
                 case AS_IS:
                     type = "As-is";

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ImageOptionsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ImageOptionsController.java
@@ -129,11 +129,11 @@ public class ImageOptionsController
             changeImageChecksum.setChecked(lastSettings.getChangeImageChecksum());
             fixExif.setChecked(lastSettings.getFixExif());
             ImageReencodingPresenter.ReencodeSettings lastReencode = lastSettings.getReencodeSettings();
-            if (lastReencode != null) {
+            if (lastReencode != null && presenter.hasAttachedFile()) {
                 removeMetadata.setChecked(!lastReencode.isDefault());
                 removeMetadata.setEnabled(!lastReencode.isDefault());
                 reencode.setChecked(!lastReencode.isDefault());
-                reencode.setText("Re-encode " + lastReencode.prettyPrint(presenter.getImageFormat()));
+                reencode.setText(String.format("Re-encode %s", lastReencode.prettyPrint(presenter.getImageFormat())));
             } else {
                 removeMetadata.setChecked(lastSettings.getRemoveMetadata());
             }
@@ -256,7 +256,7 @@ public class ImageOptionsController
         removeMetadata.setButtonTintList(ColorStateList.valueOf(ThemeHelper.getTheme().textSecondary));
         removeMetadata.setTextColor(ColorStateList.valueOf(ThemeHelper.getTheme().textSecondary));
 
-        reencode.setText("Re-encode " + reencodeSettings.prettyPrint(presenter.getImageFormat()));
+        reencode.setText(String.format("Re-encode %s", reencodeSettings.prettyPrint(presenter.getImageFormat())));
 
         presenter.setReencode(reencodeSettings);
     }


### PR DESCRIPTION
…previous settings to it

Closes #498 

This is not a 100% fix, it's just to prevent this thing from crashing when `reply.file == null`. It's still unknown how this happens. 