### PR TITLE
Update FSAF to version alpha20

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -258,7 +258,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.12'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha19'
+    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha20'
     implementation 'joda-time:joda-time:2.10.5'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -258,7 +258,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.12'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha18'
+    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha19'
     implementation 'joda-time:joda-time:2.10.5'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/di/AppModule.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/di/AppModule.java
@@ -100,8 +100,8 @@ public class AppModule {
 
     @Provides
     @Singleton
-    public FileManager provideFileManager() {
-        DirectoryManager directoryManager = new DirectoryManager();
+    public FileManager provideFileManager(Context applicationContext) {
+        DirectoryManager directoryManager = new DirectoryManager(applicationContext);
 
         // Add new base directories here
         LocalThreadsBaseDirectory localThreadsBaseDirectory = new LocalThreadsBaseDirectory();

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/settings/base_directory/LocalThreadsBaseDirectory.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/settings/base_directory/LocalThreadsBaseDirectory.kt
@@ -8,11 +8,21 @@ import java.io.File
 class LocalThreadsBaseDirectory : BaseDirectory() {
 
     override fun getDirFile(): File? {
-        return File(ChanSettings.localThreadLocation.fileApiBaseDir.get())
+        val path = ChanSettings.localThreadLocation.fileApiBaseDir.get()
+        if (path.isEmpty()) {
+            return null
+        }
+
+        return File(path)
     }
 
     override fun getDirUri(): Uri? {
-        return Uri.parse(ChanSettings.localThreadLocation.safBaseDir.get())
+        val path = ChanSettings.localThreadLocation.safBaseDir.get()
+        if (path.isEmpty()) {
+            return null
+        }
+
+        return Uri.parse(path)
     }
 
     override fun currentActiveBaseDirType(): ActiveBaseDirType {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/settings/base_directory/SavedFilesBaseDirectory.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/settings/base_directory/SavedFilesBaseDirectory.kt
@@ -5,15 +5,24 @@ import com.github.adamantcheese.chan.core.settings.ChanSettings
 import com.github.k1rakishou.fsaf.manager.base_directory.BaseDirectory
 import java.io.File
 
-class SavedFilesBaseDirectory(
-) : BaseDirectory() {
+class SavedFilesBaseDirectory : BaseDirectory() {
 
     override fun getDirFile(): File? {
-        return File(ChanSettings.saveLocation.fileApiBaseDir.get())
+        val path = ChanSettings.saveLocation.fileApiBaseDir.get()
+        if (path.isEmpty()) {
+            return null
+        }
+
+        return File(path)
     }
 
     override fun getDirUri(): Uri? {
-        return Uri.parse(ChanSettings.saveLocation.safBaseDir.get())
+        val path = ChanSettings.saveLocation.safBaseDir.get()
+        if (path.isEmpty()) {
+            return null
+        }
+
+        return Uri.parse(path)
     }
 
     override fun currentActiveBaseDirType(): ActiveBaseDirType {


### PR DESCRIPTION
- Apparently some users sometimes lose access to their SAF base directories.
This may actually happen when the SAF base directory URI loses the read/write permissions.
Users can do that in settings.
So now FSAF will check whether the SAF base directory still has both permissions and if not it will log it.
So the next time when somebody is complaining that they have to set the base directory again they would be able to provide logs, and with logs it will become obvious wtf is going on. (It may actually be another reason, but this one is the most possible for now).