### PR TITLE
Add OLED-friendly Tomorrow-based theme (Tomorrow Black)

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/ThemeHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/ThemeHelper.java
@@ -77,6 +77,13 @@ public class ThemeHelper {
                 ROBOTO_MEDIUM,
                 ROBOTO_CONDENSED
         ));
+        themes.add(new DarkTheme("Tomorrow Black",
+                "tomorrow_black",
+                R.style.Chan_Theme_TomorrowBlack,
+                PrimaryColor.BLACK,
+                ROBOTO_MEDIUM,
+                ROBOTO_CONDENSED
+        ));
         themes.add(new Theme("Yotsuba",
                 "yotsuba",
                 R.style.Chan_Theme_Yotsuba,

--- a/Kuroba/app/src/main/res/values/styles.xml
+++ b/Kuroba/app/src/main/res/values/styles.xml
@@ -161,6 +161,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </style>
 
+    <style name="Chan.Theme.TomorrowBlack" parent="Chan.Theme.Tomorrow">
+        <item name="backcolor">#000000</item>
+        <item name="backcolor_secondary">#212121</item>
+
+        <item name="post_spoiler_color">#2c2c2c</item>
+    </style>
+
     <style name="Chan.Theme.Insomnia" parent="Chan.Theme.Dark">
         <item name="colorAccent">#5f89ac</item>
 


### PR DESCRIPTION
This adds a new Tomorrow-based theme that mimics the same changes from Dark->Black. I think Tomorrow has gentler foreground colors than Black, but it would be nice to black out the background in it.