### PR TITLE
Check whether the download is not canceled yet before merging chunks into the cache file

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkMerger.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkMerger.kt
@@ -30,6 +30,11 @@ internal class ChunkMerger(
                         "chunks count = ${chunkSuccessEvents.size}")
             }
 
+            val isRunning = activeDownloads.get(url)?.cancelableDownload?.isRunning() ?: false
+            if (!isRunning) {
+                activeDownloads.throwCancellationException(url)
+            }
+
             try {
                 // Must be sorted in ascending order!!!
                 val sortedChunkEvents = chunkSuccessEvents.sortedBy { event -> event.chunk.start }


### PR DESCRIPTION
When quickly swiping through the images it is possible to trigger a state when an image was not yet completely downloaded and we somehow got into the merging stage. Because we didn't check before whether the download is canceled or not at that stage it was possible to see an error toast telling us that an image has the wrong hash. This check fixes it. 