### PR TITLE
Add 8kun 

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/downloader/PartialContentSupportChecker.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/downloader/PartialContentSupportChecker.kt
@@ -233,13 +233,23 @@ internal class PartialContentSupportChecker(
 
         val contentLengthValue = response.header(CONTENT_LENGTH_HEADER)
         if (contentLengthValue == null) {
-            log(TAG, "($url) does not support partial content (CONTENT_LENGTH_HEADER is null")
-            emitter.onSuccess(cache(url, PartialContentCheckResult(false)))
-            return
+            // 8kun doesn't send Content-Length header whatsoever, but it sends correct file size
+            // in thread.json. So we can try using that.
+
+            if (!canWeUseFileSizeFromJson(url)) {
+                log(TAG, "($url) does not support partial content (CONTENT_LENGTH_HEADER is null")
+                emitter.onSuccess(cache(url, PartialContentCheckResult(false)))
+                return
+            }
         }
 
-        val length = contentLengthValue.toLongOrNull()
-        if (length == null) {
+        val length = if (contentLengthValue != null) {
+            contentLengthValue.toLongOrNull()
+        } else {
+            activeDownloads.get(url)?.extraInfo?.fileSize ?: -1L
+        }
+
+        if (length == null || length <= 0) {
             log(TAG, "($url) does not support partial content " +
                     "(bad CONTENT_LENGTH_HEADER = ${contentLengthValue})")
             emitter.onSuccess(cache(url, PartialContentCheckResult(false)))
@@ -271,6 +281,24 @@ internal class PartialContentSupportChecker(
         )
 
         emitter.onSuccess(cache(url, result))
+    }
+
+    private fun canWeUseFileSizeFromJson(url: String): Boolean {
+        val fileSize = activeDownloads.get(url)?.extraInfo?.fileSize ?: -1L
+        if (fileSize <= 0) {
+            return false
+        }
+
+        val host = url.toHttpUrlOrNull()?.host
+        if (host == null) {
+            logError(TAG, "Bad url, can't extract host: $url")
+            return false
+        }
+
+        return siteResolver.findSiteForUrl(host)
+                ?.chunkDownloaderSiteProperties
+                ?.siteSendsCorrectFileSizeInBytes
+                ?: false
     }
 
     private fun cache(

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/SiteRegistry.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/SiteRegistry.java
@@ -19,6 +19,7 @@ package com.github.adamantcheese.chan.core.site;
 import android.util.SparseArray;
 
 import com.github.adamantcheese.chan.core.site.sites.Arisuchan;
+import com.github.adamantcheese.chan.core.site.sites.Kun8;
 import com.github.adamantcheese.chan.core.site.sites.Lainchan;
 import com.github.adamantcheese.chan.core.site.sites.Sushichan;
 import com.github.adamantcheese.chan.core.site.sites.Wired7;
@@ -44,6 +45,7 @@ public class SiteRegistry {
         URL_HANDLERS.add(Dvach.URL_HANDLER);
         URL_HANDLERS.add(Wired7.URL_HANDLER);
         //chan55 was here but was removed
+        URL_HANDLERS.add(Kun8.URL_HANDLER);
     }
 
     static {
@@ -59,5 +61,6 @@ public class SiteRegistry {
         SITE_CLASSES.put(5, Dvach.class);
         SITE_CLASSES.put(6, Wired7.class);
         //chan55 was here but was removed; don't use ID 7
+        SITE_CLASSES.put(8, Kun8.class);
     }
 }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/Kun8.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/Kun8.java
@@ -1,0 +1,154 @@
+package com.github.adamantcheese.chan.core.site.sites;
+
+
+import androidx.annotation.NonNull;
+
+import com.github.adamantcheese.chan.core.model.Post;
+import com.github.adamantcheese.chan.core.model.orm.Loadable;
+import com.github.adamantcheese.chan.core.site.ChunkDownloaderSiteProperties;
+import com.github.adamantcheese.chan.core.site.Site;
+import com.github.adamantcheese.chan.core.site.SiteAuthentication;
+import com.github.adamantcheese.chan.core.site.SiteIcon;
+import com.github.adamantcheese.chan.core.site.common.CommonSite;
+import com.github.adamantcheese.chan.core.site.common.MultipartHttpCall;
+import com.github.adamantcheese.chan.core.site.common.vichan.VichanActions;
+import com.github.adamantcheese.chan.core.site.common.vichan.VichanApi;
+import com.github.adamantcheese.chan.core.site.common.vichan.VichanCommentParser;
+import com.github.adamantcheese.chan.core.site.common.vichan.VichanEndpoints;
+import com.github.adamantcheese.chan.core.site.http.DeleteRequest;
+import com.github.adamantcheese.chan.core.site.http.Reply;
+
+import java.util.Map;
+
+import okhttp3.HttpUrl;
+
+public class Kun8 extends CommonSite {
+    private final ChunkDownloaderSiteProperties chunkDownloaderSiteProperties;
+
+    public static final CommonSiteUrlHandler URL_HANDLER = new CommonSiteUrlHandler() {
+        private final String[] mediaHosts = new String[]{"media.8kun.top"};
+
+        @Override
+        public Class<? extends Site> getSiteClass() {
+            return Kun8.class;
+        }
+
+        @Override
+        public HttpUrl getUrl() {
+            return HttpUrl.parse("https://8kun.top/");
+        }
+
+        @Override
+        public String[] getNames() {
+            return new String[]{"8kun", "8kun"};
+        }
+
+        @Override
+        public String[] getMediaHosts() {
+            return mediaHosts;
+        }
+
+        @Override
+        public String desktopUrl(Loadable loadable, int postNo) {
+            if (loadable.isCatalogMode()) {
+                return getUrl().newBuilder().addPathSegment(loadable.boardCode).toString();
+            } else if (loadable.isThreadMode()) {
+                return getUrl().newBuilder()
+                        .addPathSegment(loadable.boardCode).addPathSegment("res")
+                        .addPathSegment(loadable.no + ".html")
+                        .toString();
+            } else {
+                return getUrl().toString();
+            }
+        }
+    };
+
+    public Kun8() {
+        chunkDownloaderSiteProperties = new ChunkDownloaderSiteProperties(true, true);
+    }
+
+    @Override
+    public void setup() {
+        setName("8kun");
+        setIcon(SiteIcon.fromFavicon(HttpUrl.parse("https://8kun.top/static/favicon.ico")));
+        setBoardsType(BoardsType.INFINITE);
+        setResolvable(URL_HANDLER);
+
+        setConfig(new CommonConfig() {
+            @Override
+            public boolean feature(Feature feature) {
+                return feature == Feature.POSTING || feature == Feature.POST_DELETE;
+            }
+        });
+
+        setEndpoints(new VichanEndpoints(this,
+                "https://8kun.top","https://sys.8kun.top") {
+            @Override
+            public HttpUrl imageUrl(Post.Builder post, Map<String, String> arg) {
+                return HttpUrl.parse("https://media.8kun.top/" + "file_store/" + (arg.get("tim") + "." + arg.get("ext")));
+
+            }
+
+            @Override
+            public HttpUrl thumbnailUrl(Post.Builder post, boolean spoiler, Map<String, String> arg) {
+                String ext;
+                switch (arg.get("ext")) {
+                    case "jpeg":
+                    case "jpg":
+                    case "png":
+                    case "gif":
+                        ext = arg.get("ext");
+                        break;
+                    default:
+                        ext = "jpg";
+                        break;
+                }
+
+                return HttpUrl.parse("https://media.8kun.top/" + "file_store/" + "thumb/" + (arg.get("tim") + "." + ext));
+            }
+        });
+
+        setActions(new VichanActions(this) {
+            @Override
+            public void setupPost(Reply reply, MultipartHttpCall call) {
+                super.setupPost(reply, call);
+
+                if (reply.loadable.isThreadMode()) {
+                    // "thread" is already added in VichanActions.
+                    call.parameter("post", "New Reply");
+                } else {
+                    call.parameter("post", "New Thread");
+                    call.parameter("page", "1");
+                }
+            }
+
+            @Override
+            public boolean requirePrepare() {
+                // We don't need to check the antispam fields for 8chan.
+                return false;
+            }
+
+            @Override
+            public SiteAuthentication postAuthenticate() {
+                return SiteAuthentication.fromUrl("https://8kun.top/dnsbls_bypass.php",
+                        "You failed the CAPTCHA",
+                        "You may now go back and make your post");
+            }
+
+            @Override
+            public void delete(DeleteRequest deleteRequest, DeleteListener deleteListener) {
+                super.delete(deleteRequest, deleteListener);
+            }
+        });
+
+        setApi(new VichanApi(this));
+
+        setParser(new VichanCommentParser());
+    }
+
+    @NonNull
+    @Override
+    public ChunkDownloaderSiteProperties getChunkDownloaderSiteProperties() {
+        return chunkDownloaderSiteProperties;
+    }
+}

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/PartialContentOkHttpDispatcher.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/PartialContentOkHttpDispatcher.kt
@@ -30,7 +30,7 @@ class PartialContentOkHttpDispatcher : Dispatcher() {
             val (start, end) = rangeList.filterNotNull()
 
             val buffer = Buffer()
-                    .readFrom(javaClass.classLoader.getResourceAsStream(imageName))
+                    .readFrom(javaClass.classLoader!!.getResourceAsStream(imageName))
 
             val outputBuffer = buffer.use { buff ->
                 if (start > 0) {

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/TestHelpers.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/TestHelpers.kt
@@ -3,7 +3,7 @@ package com.github.adamantcheese.chan.core.cache
 import com.github.adamantcheese.chan.core.cache.downloader.CancelableDownload
 import com.github.adamantcheese.chan.core.cache.downloader.DownloadRequestExtraInfo
 import com.github.adamantcheese.chan.core.cache.downloader.FileDownloadRequest
-import com.github.k1rakishou.fsaf.file.AbstractFile
+import com.github.k1rakishou.fsaf.file.RawFile
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import okhttp3.mockwebserver.MockWebServer
@@ -26,7 +26,7 @@ internal fun createFileDownloadRequest(
         url: String,
         chunksCount: Int = 1,
         isBatchDownload: Boolean = false,
-        file: AbstractFile = mock()
+        file: RawFile
 ): FileDownloadRequest {
     val executor = mock<ExecutorService>()
 

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkDownloaderTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkDownloaderTest.kt
@@ -61,10 +61,11 @@ class ChunkDownloaderTest {
             server.start()
 
             val url = server.url("/${imageName}").toString()
-            val request = createFileDownloadRequest(url, chunks.size)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, chunks.size, file = output)
             activeDownloads.put(url, request)
 
-            val wholeFile = javaClass.classLoader.getResourceAsStream(imageName)
+            val wholeFile = javaClass.classLoader!!.getResourceAsStream(imageName)
                     .use { it.readBytes() }
 
             chunks.forEach { chunk ->

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkPersisterTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkPersisterTest.kt
@@ -65,7 +65,7 @@ class ChunkPersisterTest {
     @Test
     fun `test try store two chunks one chunk fails`() {
         val url = "http://testUrl.com/123.jpg"
-        val fileBytes = javaClass.classLoader.getResourceAsStream("test_img1.jpg").readBytes()
+        val fileBytes = javaClass.classLoader!!.getResourceAsStream("test_img1.jpg").readBytes()
         val chunksCount = 2
         val chunks = chunkLong(fileBytes.size.toLong(), chunksCount, MIN_CHUNK_SIZE)
         val chunkResponses = createChunkResponses(url, chunks, fileBytes)
@@ -121,7 +121,7 @@ class ChunkPersisterTest {
     @Test
     fun `test store two chunks on the disk both succeed`() {
         val url = "http://testUrl.com/123.jpg"
-        val fileBytes = javaClass.classLoader.getResourceAsStream("test_img1.jpg").readBytes()
+        val fileBytes = javaClass.classLoader!!.getResourceAsStream("test_img1.jpg").readBytes()
         val chunksCount = 2
         val chunks = chunkLong(fileBytes.size.toLong(), chunksCount, MIN_CHUNK_SIZE)
         val chunkResponses = createChunkResponses(url, chunks, fileBytes)

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ConcurrentChunkedFileDownloaderTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ConcurrentChunkedFileDownloaderTest.kt
@@ -59,7 +59,7 @@ class ConcurrentChunkedFileDownloaderTest {
     fun `test cancel one chunk download request`() {
         withServer { server ->
             val buffer = Buffer()
-                    .readFrom(javaClass.classLoader.getResourceAsStream("test_img1.jpg"))
+                    .readFrom(javaClass.classLoader!!.getResourceAsStream("test_img1.jpg"))
 
             val response = MockResponse()
                     .setResponseCode(200)
@@ -141,7 +141,7 @@ class ConcurrentChunkedFileDownloaderTest {
             )
 
             val imageSizeList = imageNameList.map { imageName ->
-                return@map javaClass.classLoader.getResourceAsStream(imageName).use { stream ->
+                return@map javaClass.classLoader!!.getResourceAsStream(imageName).use { stream ->
                     stream.available()
                 }
             }
@@ -272,7 +272,7 @@ class ConcurrentChunkedFileDownloaderTest {
     fun `test download the whole image in one chunk when everything is ok`() {
         withServer { server ->
             val buffer = Buffer()
-                    .readFrom(javaClass.classLoader.getResourceAsStream("test_img1.jpg"))
+                    .readFrom(javaClass.classLoader!!.getResourceAsStream("test_img1.jpg"))
 
             val response = MockResponse()
                     .setResponseCode(200)
@@ -306,7 +306,7 @@ class ConcurrentChunkedFileDownloaderTest {
         withServer { server ->
             val imageName = "test_img1.jpg"
 
-            val fileSize = javaClass.classLoader.getResourceAsStream(imageName).use { stream ->
+            val fileSize = javaClass.classLoader!!.getResourceAsStream(imageName).use { stream ->
                 stream.available()
             }
 

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/PartialContentSupportCheckerTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/PartialContentSupportCheckerTest.kt
@@ -1,8 +1,10 @@
 package com.github.adamantcheese.chan.core.cache.downloader
 
+import com.github.adamantcheese.chan.core.cache.CacheHandler
 import com.github.adamantcheese.chan.core.cache.createFileDownloadRequest
 import com.github.adamantcheese.chan.core.cache.withServer
 import com.github.adamantcheese.chan.utils.AndroidUtils
+import com.github.k1rakishou.fsaf.file.RawFile
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import org.junit.After
@@ -23,6 +25,7 @@ class PartialContentSupportCheckerTest {
     private lateinit var okHttpClient: OkHttpClient
     private lateinit var activeDownloads: ActiveDownloads
     private lateinit var partialContentSupportChecker: PartialContentSupportChecker
+    private lateinit var cacheHandler: CacheHandler
 
     @Before
     fun setUp() {
@@ -31,6 +34,7 @@ class PartialContentSupportCheckerTest {
         okHttpClient = testModule.provideOkHttpClient()
         activeDownloads = testModule.provideActiveDownloads()
         partialContentSupportChecker = testModule.providePartialContentSupportChecker()
+        cacheHandler = testModule.provideCacheHandler()
     }
 
     @After
@@ -43,7 +47,8 @@ class PartialContentSupportCheckerTest {
     @Test
     fun `test check for batch request should return supportsPartialContentDownload == false`() {
         val url = "http://4chan.org/image1.jpg"
-        val request = createFileDownloadRequest(url, isBatchDownload = true)
+        val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+        val request = createFileDownloadRequest(url, isBatchDownload = true, file = output)
         activeDownloads.put(url, request)
 
         partialContentSupportChecker.check(url)
@@ -71,7 +76,8 @@ class PartialContentSupportCheckerTest {
             server.start()
 
             val url = server.url("/image1.jpg").toString()
-            val request = createFileDownloadRequest(url)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, file = output)
             activeDownloads.put(url, request)
 
             partialContentSupportChecker.check(url)
@@ -108,7 +114,8 @@ class PartialContentSupportCheckerTest {
             server.start()
 
             val url = server.url("/image1.jpg").toString()
-            val request = createFileDownloadRequest(url)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, file = output)
             activeDownloads.put(url, request)
 
 
@@ -142,7 +149,8 @@ class PartialContentSupportCheckerTest {
             server.start()
 
             val url = server.url("/image1.jpg").toString()
-            val request = createFileDownloadRequest(url)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, file = output)
             activeDownloads.put(url, request)
 
             val testObserver = partialContentSupportChecker.check(url)
@@ -182,7 +190,8 @@ class PartialContentSupportCheckerTest {
             server.start()
 
             val url = server.url("/image1.jpg").toString()
-            val request = createFileDownloadRequest(url)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, file = output)
             activeDownloads.put(url, request)
 
             val testObserver = partialContentSupportChecker.check(url)
@@ -216,7 +225,8 @@ class PartialContentSupportCheckerTest {
             server.start()
 
             val url = server.url("/image1.jpg").toString()
-            val request = createFileDownloadRequest(url)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, file = output)
             activeDownloads.put(url, request)
 
             partialContentSupportChecker.check(url)
@@ -247,7 +257,8 @@ class PartialContentSupportCheckerTest {
             server.start()
 
             val url = server.url("/image1.jpg").toString()
-            val request = createFileDownloadRequest(url)
+            val output = cacheHandler.getOrCreateCacheFile(url) as RawFile
+            val request = createFileDownloadRequest(url, file = output)
             activeDownloads.put(url, request)
 
             partialContentSupportChecker.check(url)

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/TestModule.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/TestModule.kt
@@ -1,10 +1,12 @@
 package com.github.adamantcheese.chan.core.cache.downloader
 
 import com.github.adamantcheese.chan.core.cache.CacheHandler
+import com.github.adamantcheese.chan.core.site.SiteResolver
 import com.github.k1rakishou.fsaf.BadPathSymbolResolutionStrategy
 import com.github.k1rakishou.fsaf.FileManager
 import com.github.k1rakishou.fsaf.file.RawFile
 import com.github.k1rakishou.fsaf.manager.base_directory.DirectoryManager
+import com.nhaarman.mockitokotlin2.mock
 import io.reactivex.schedulers.Schedulers
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertNotNull
@@ -23,6 +25,7 @@ class TestModule {
     private var partialContentSupportChecker: PartialContentSupportChecker? = null
     private var chunkPersister: ChunkPersister? = null
     private var chunkMerger: ChunkMerger? = null
+    private var siteResolver: SiteResolver? = null
 
     private var cacheDirFile: RawFile? = null
     private var chunksCacheDirFile: RawFile? = null
@@ -43,11 +46,20 @@ class TestModule {
         return chunkPersister!!
     }
 
+    internal fun provideSiteResolver(): SiteResolver {
+        if (siteResolver == null) {
+            siteResolver = mock<SiteResolver>()
+        }
+
+        return siteResolver!!
+    }
+
     internal fun provideChunkPersister(): ChunkMerger {
         if (chunkMerger == null) {
             chunkMerger = ChunkMerger(
                     provideFileManager(),
                     provideCacheHandler(),
+                    provideSiteResolver(),
                     provideActiveDownloads(),
                     false
             )
@@ -61,6 +73,7 @@ class TestModule {
             partialContentSupportChecker = PartialContentSupportChecker(
                     provideOkHttpClient(),
                     provideActiveDownloads(),
+                    provideSiteResolver(),
                     250L
             )
         }
@@ -110,7 +123,7 @@ class TestModule {
             fileManager = FileManager(
                     provideContext(),
                     BadPathSymbolResolutionStrategy.ThrowAnException,
-                    DirectoryManager()
+                    DirectoryManager(provideContext())
             )
         }
 


### PR DESCRIPTION
(taken from Clovers PRs, original implementation by jirn073-76)

And couple of improvement for FileCacheV2 to take into account 8kun peculiarities

- Checked thread/post viewing, chunked image downloading. Couldn't check whether I can post or not because it would return 403 to me (guess that's because of VPN?). Can't use it without VPN because they banned my country (?), redirects me to a different site.

Closes #383

Since we promised to add it in this release, may as well actually do that. Taken from here - https://github.com/chandevel/Clover/pull/760

Couldn't check posting because it returns me 403 probably because of VPN and I can't access it without VPN because it redirects me to vanwatech com