### PR TITLE
(#550) Fix for gif not having any gestures

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
@@ -473,6 +473,7 @@ public class MultiImageView
         GifImageView view = new GifImageView(getContext());
         view.setImageDrawable(drawable);
 
+        view.setOnClickListener(null);
         view.setOnTouchListener((view1, motionEvent) -> gestureDetector.onTouchEvent(motionEvent));
         onModeLoaded(Mode.GIFIMAGE, view);
     }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/ThumbnailImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/ThumbnailImageView.java
@@ -5,15 +5,15 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import android.widget.ImageView;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatImageView;
 
 import com.github.adamantcheese.chan.R;
 import com.github.adamantcheese.chan.core.model.PostImage;
 
 public class ThumbnailImageView
-        extends ImageView {
+        extends AppCompatImageView {
 
     private PostImage.Type type = PostImage.Type.STATIC;
     private Drawable playIcon;


### PR DESCRIPTION
Apparently GifImageView has some internal click handling and we need to explicitly null the click listener so it won't intercept our touch events