### PR TITLE
(#584) Silenced all the places where PostImage.imageUrl was accessed + add tons of logs for such cases

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/image/ImageLoaderV2.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/image/ImageLoaderV2.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
-import static com.github.adamantcheese.chan.utils.BackgroundUtils.runOnMainThread;
-
 public class ImageLoaderV2 {
     private static final String TAG = "ImageLoaderV2";
 
@@ -59,7 +57,7 @@ public class ImageLoaderV2 {
 
         if (loadable.isLocal() || loadable.isDownloading()) {
             String formattedName;
-            Logger.d(TAG, "Loading image " + postImage.imageUrl.toString() + " from the disk");
+            Logger.d(TAG, "Loading image " + getImageUrlForLogs(postImage) + " from the disk");
 
             if (postImage.spoiler) {
                 String extension = StringUtils.extractFileNameExtension(postImage.spoilerThumbnailUrl.toString());
@@ -84,12 +82,12 @@ public class ImageLoaderV2 {
             }
 
             return getFromDisk(loadable, formattedName, postImage.spoiler, imageListener, width, height, () -> {
-                Logger.d(TAG, "Falling back to imageLoaderV1 load the image " + postImage.imageUrl.toString());
+                Logger.d(TAG, "Falling back to imageLoaderV1 load the image " + getImageUrlForLogs(postImage));
 
                 return imageLoader.get(postImage.getThumbnailUrl().toString(), imageListener, width, height);
             });
         } else {
-            Logger.d(TAG, "Loading image " + postImage.imageUrl.toString() + " via the imageLoaderV1");
+            Logger.d(TAG, "Loading image " + getImageUrlForLogs(postImage) + " via the imageLoaderV1");
 
             return imageLoader.get(postImage.getThumbnailUrl().toString(), imageListener, width, height);
         }
@@ -212,6 +210,16 @@ public class ImageLoaderV2 {
         });
 
         return container;
+    }
+
+    private String getImageUrlForLogs(PostImage postImage) {
+        if (postImage.imageUrl != null) {
+            return postImage.imageUrl.toString();
+        } else if (postImage.thumbnailUrl != null) {
+            return postImage.thumbnailUrl.toString();
+        }
+
+        return "No image url";
     }
 
     private void postError(ImageListener imageListener, String message) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/mapper/PostImageMapper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/mapper/PostImageMapper.java
@@ -1,5 +1,7 @@
 package com.github.adamantcheese.chan.core.mapper;
 
+import androidx.annotation.Nullable;
+
 import com.github.adamantcheese.chan.core.model.PostImage;
 import com.github.adamantcheese.chan.core.model.save.SerializablePostImage;
 
@@ -10,7 +12,12 @@ import okhttp3.HttpUrl;
 
 public class PostImageMapper {
 
+    @Nullable
     public static SerializablePostImage toSerializablePostImage(PostImage postImage) {
+        if (postImage.imageUrl == null) {
+            return null;
+        }
+
         return new SerializablePostImage(
                 postImage.serverFilename,
                 postImage.filename,
@@ -30,17 +37,27 @@ public class PostImageMapper {
         List<SerializablePostImage> serializablePostImageList = new ArrayList<>(postImageList.size());
 
         for (PostImage postImage : postImageList) {
-            serializablePostImageList.add(toSerializablePostImage(postImage));
+            SerializablePostImage serializablePostImage = toSerializablePostImage(postImage);
+            if (serializablePostImage == null) {
+                continue;
+            }
+
+            serializablePostImageList.add(serializablePostImage);
         }
 
         return serializablePostImageList;
     }
 
+    @Nullable
     public static PostImage fromSerializablePostImage(SerializablePostImage serializablePostImage) {
         HttpUrl imageUrl = null;
 
         if (serializablePostImage.getImageUrl() != null) {
             imageUrl = HttpUrl.parse(serializablePostImage.getImageUrl());
+        }
+
+        if (imageUrl == null) {
+            return null;
         }
 
         return new PostImage.Builder().serverFilename(serializablePostImage.getOriginalName())
@@ -61,7 +78,12 @@ public class PostImageMapper {
         List<PostImage> postImageList = new ArrayList<>(serializablePostImageList.size());
 
         for (SerializablePostImage serializablePostImage : serializablePostImageList) {
-            postImageList.add(fromSerializablePostImage(serializablePostImage));
+            PostImage postImage = fromSerializablePostImage(serializablePostImage);
+            if (postImage == null) {
+                continue;
+            }
+
+            postImageList.add(postImage);
         }
 
         return postImageList;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
@@ -18,6 +18,7 @@ package com.github.adamantcheese.chan.core.model;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.github.adamantcheese.chan.core.settings.ChanSettings;
@@ -41,6 +42,7 @@ public class PostImage {
     public final String serverFilename;
     public final HttpUrl thumbnailUrl;
     public final HttpUrl spoilerThumbnailUrl;
+    @Nullable
     public final HttpUrl imageUrl;
     public final String filename;
     public final String extension;
@@ -131,7 +133,11 @@ public class PostImage {
             return this;
         }
 
-        public Builder imageUrl(HttpUrl imageUrl) {
+        public Builder imageUrl(@NonNull HttpUrl imageUrl) {
+            if (imageUrl == null) {
+                throw new NullPointerException("imageUrl must not be null!");
+            }
+
             this.imageUrl = imageUrl;
             return this;
         }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -565,19 +565,22 @@ public class ThreadPresenter
                 cancelPrefetching();
 
                 for (Post p : result.getPosts()) {
-                    if (p.images != null) {
-                        for (PostImage postImage : p.images) {
-                            if (cacheHandler.exists(postImage.imageUrl.toString())) {
-                                continue;
-                            }
+                    for (PostImage postImage : p.images) {
+                        if (postImage.imageUrl == null) {
+                            Logger.e(TAG, "onChanLoaderData() postImage.imageUrl == null");
+                            continue;
+                        }
 
-                            if ((postImage.type == PostImage.Type.STATIC || postImage.type == PostImage.Type.GIF)
-                                    && shouldLoadForNetworkType(ChanSettings.imageAutoLoadNetwork.get())) {
-                                postImageList.add(postImage);
-                            } else if (postImage.type == PostImage.Type.MOVIE
-                                    && shouldLoadForNetworkType(ChanSettings.videoAutoLoadNetwork.get())) {
-                                postImageList.add(postImage);
-                            }
+                        if (cacheHandler.exists(postImage.imageUrl.toString())) {
+                            continue;
+                        }
+
+                        if ((postImage.type == PostImage.Type.STATIC || postImage.type == PostImage.Type.GIF)
+                                && shouldLoadForNetworkType(ChanSettings.imageAutoLoadNetwork.get())) {
+                            postImageList.add(postImage);
+                        } else if (postImage.type == PostImage.Type.MOVIE
+                                && shouldLoadForNetworkType(ChanSettings.videoAutoLoadNetwork.get())) {
+                            postImageList.add(postImage);
                         }
                     }
                 }
@@ -843,6 +846,11 @@ public class ThreadPresenter
         for (Post item : posts) {
             if (!item.images.isEmpty()) {
                 for (PostImage image : item.images) {
+                    if (image.imageUrl == null) {
+                        Logger.e(TAG, "onThumbnailClicked() image.imageUrl == null");
+                        continue;
+                    }
+
                     if (!item.deleted.get() || instance(CacheHandler.class).exists(image.imageUrl.toString())) {
                         //deleted posts always have 404'd images, but let it through if the file exists in cache
                         images.add(image);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaveTask.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaveTask.java
@@ -48,7 +48,6 @@ import static com.github.adamantcheese.chan.core.saver.ImageSaver.BundledDownloa
 import static com.github.adamantcheese.chan.core.saver.ImageSaver.BundledDownloadResult.Success;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getAppContext;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.openIntent;
-import static com.github.adamantcheese.chan.utils.BackgroundUtils.runOnMainThread;
 
 public class ImageSaveTask
         extends FileCacheListener {
@@ -90,6 +89,10 @@ public class ImageSaveTask
     }
 
     public String getPostImageUrl() {
+        if (postImage.imageUrl == null) {
+            throw new NullPointerException("imageUrl is null! loadable = " + loadable.toShortString());
+        }
+
         return postImage.imageUrl.toString();
     }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
@@ -35,6 +35,7 @@ import com.github.adamantcheese.chan.core.model.PostLinkable;
 import com.github.adamantcheese.chan.core.settings.ChanSettings;
 import com.github.adamantcheese.chan.ui.theme.Theme;
 import com.github.adamantcheese.chan.utils.AndroidUtils;
+import com.github.adamantcheese.chan.utils.Logger;
 
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
@@ -60,6 +61,7 @@ import static com.github.adamantcheese.chan.utils.AndroidUtils.sp;
 
 @AnyThread
 public class CommentParserHelper {
+    private static final String TAG = "CommentParserHelper";
     private static final LinkExtractor LINK_EXTRACTOR =
             LinkExtractor.builder().linkTypes(EnumSet.of(LinkType.URL)).build();
 
@@ -221,11 +223,18 @@ public class CommentParserHelper {
                                         || ((String) linkable.value).endsWith("mp4");
                         String spoilerThumbnail =
                                 "https://raw.githubusercontent.com/Adamantcheese/Kuroba/multi-feature/docs/internal_spoiler.png";
+
+                        HttpUrl imageUrl = HttpUrl.parse((String) linkable.value);
+                        if (imageUrl == null) {
+                            Logger.e(TAG, "addPostImages() couldn't parse linkable.value (" + linkable.value + ")");
+                            continue;
+                        }
+
                         post.images(Collections.singletonList(new PostImage.Builder().serverFilename(matcher.group(1))
                                 //spoiler thumb for some linked items, the image itself for the rest; probably not a great idea
                                 .thumbnailUrl(HttpUrl.parse(noThumbnail ? spoilerThumbnail : (String) linkable.value))
                                 .spoilerThumbnailUrl(HttpUrl.parse(spoilerThumbnail))
-                                .imageUrl(HttpUrl.parse((String) linkable.value))
+                                .imageUrl(imageUrl)
                                 .filename(matcher.group(1))
                                 .extension(matcher.group(2))
                                 .spoiler(true)

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCell.java
@@ -78,6 +78,7 @@ import com.github.adamantcheese.chan.ui.view.FloatingMenu;
 import com.github.adamantcheese.chan.ui.view.FloatingMenuItem;
 import com.github.adamantcheese.chan.ui.view.PostImageThumbnailView;
 import com.github.adamantcheese.chan.ui.view.ThumbnailView;
+import com.github.adamantcheese.chan.utils.Logger;
 
 import java.text.BreakIterator;
 import java.util.ArrayList;
@@ -642,6 +643,11 @@ public class PostCell
             boolean first = true;
             for (int i = 0; i < post.images.size(); i++) {
                 PostImage image = post.images.get(i);
+                if (image.imageUrl == null) {
+                    Logger.e(TAG, "buildThumbnails() image.imageUrl == null");
+                    continue;
+                }
+
                 PostImageThumbnailView v = new PostImageThumbnailView(getContext());
 
                 // Set the correct id.

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ImageViewerController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ImageViewerController.java
@@ -40,6 +40,7 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 
 import com.android.volley.VolleyError;
@@ -239,6 +240,11 @@ public class ImageViewerController
 
     private void openBrowserClicked(ToolbarMenuSubItem item) {
         PostImage postImage = presenter.getCurrentPostImage();
+        if (postImage.imageUrl == null) {
+            Logger.e(TAG, "openBrowserClicked() postImage.imageUrl is null");
+            return;
+        }
+
         if (ChanSettings.openLinkBrowser.get()) {
             openLink(postImage.imageUrl.toString());
         } else {
@@ -303,6 +309,11 @@ public class ImageViewerController
 
     private void saveShare(boolean share, PostImage postImage) {
         if (share && ChanSettings.shareUrl.get()) {
+            if (postImage.imageUrl == null) {
+                Logger.e(TAG, "saveShare() postImage.imageUrl == null");
+                return;
+            }
+
             shareLink(postImage.imageUrl.toString());
         } else {
             ImageSaveTask task = new ImageSaveTask(loadable, postImage, false);
@@ -489,6 +500,11 @@ public class ImageViewerController
                 for (ImageSearch imageSearch : ImageSearch.engines) {
                     if (((Integer) item.getId()) == imageSearch.getId()) {
                         final HttpUrl searchImageUrl = getSearchImageUrl(presenter.getCurrentPostImage());
+                        if (searchImageUrl == null) {
+                            Logger.e(TAG, "onFloatingMenuItemClicked() searchImageUrl == null");
+                            break;
+                        }
+
                         openLinkInBrowser((Activity) context, imageSearch.getUrl(searchImageUrl.toString()));
                         break;
                     }
@@ -760,6 +776,7 @@ public class ImageViewerController
      * @param postImage the post image
      * @return url of an image to be searched
      */
+    @Nullable
     private HttpUrl getSearchImageUrl(final PostImage postImage) {
         return postImage.type == PostImage.Type.MOVIE ? postImage.thumbnailUrl : postImage.imageUrl;
     }


### PR DESCRIPTION
- Possible fix for the source of the cause (Url parsing was not checked if it's null or not which could possibly be null when the string was not an url)

Closes #584