### PR TITLE
(#568) New domain wth ssl https://kuroba.io:8443

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -59,7 +59,7 @@ android {
         buildConfigField "String", "GITHUB_ENDPOINT", "\"https://github.com/Adamantcheese/Kuroba\""
         //this is for your development server endpoint
         //you WILL need to change the code in UpdateManager if your endpoint changes or you use a different API structure
-        buildConfigField "String", "DEV_API_ENDPOINT", "\"http://94.140.116.243:8080\""
+        buildConfigField "String", "DEV_API_ENDPOINT", "\"https://kuroba.io:8443\""
         //this is for checking who's built what in debug logs
         buildConfigField "String", "SIGNATURE", "\"8952c098\""
 

--- a/Kuroba/app/src/main/AndroidManifest.xml
+++ b/Kuroba/app/src/main/AndroidManifest.xml
@@ -30,6 +30,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <!-- !!!! REMOVE usesCleartextTraffic in a couple of months, like in april-may !!!! -->
+
     <application
         android:name=".Chan"
         android:allowBackup="true"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Releases are built by Adamantcheese whenever enough changes have been made and t
 ### [All Release APKs](https://github.com/Adamantcheese/Kuroba/releases)
 
 DEV releases are provided by K1rakishou on his server (they are built and uploaded after every new commit):
-### [Latest DEV APK](http://94.140.116.243:8080/latest_apk)
-### [All DEV APKs](http://94.140.116.243:8080/)
+### [Latest DEV APK](https://kuroba.io:8443/latest_apk)
+### [All DEV APKs](https://kuroba.io:8443/)
 
 
 Kuroba is a fast Android app for browsing imageboards, such as 4chan and 8chan. It adds inline replying, thread watching, notifications, themes, pass support, filters and a whole lot more. It is based on Clover by Floens, but has additional features added in because Floens doesn't want to merge PRs. Credits to K1rakishou for a number of features.


### PR DESCRIPTION
Closes #568

Change DEV_API_ENDPOINT to https://kuroba.io:8443 but leave usesCleartextTraffic flag as is because Android won't allow to connect to it even though it redirects to https url. So we will have to wait couple of months before everyone has updated so we can safely remove that flag.

Release builds should be able to update as they had already done - via GitHub, should be no issues here.
Old dev clients should be able to update via the http flag.
New clients will be updated via new https url.

Also checked reporting/crash reporting on dev - works fine.
Release builds will be able to send reports/crash report with the next update. For now they can't.