### PR TITLE
(#593) Fix a crash that happens when Phone layout is used, fragment is being moved and thread update happens at the same time.

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/toolbar/ToolbarContainer.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/toolbar/ToolbarContainer.java
@@ -117,7 +117,10 @@ public class ToolbarContainer
 
     public void set(NavigationItem item, Theme theme, ToolbarPresenter.AnimationStyle animation) {
         if (transitionView != null) {
-            throw new IllegalStateException("Currently in transition mode");
+            // Happens when you are in Phone layout, moving the thread fragment and at the same time
+            // thread update occurs. We probably should just skip it. But maybe there is a better
+            // solution.
+            return;
         }
 
         this.theme = theme;


### PR DESCRIPTION
Closes #593 

Might not be an ideal solution but seems fine.
STR if you want to play around with it:
- Switch to Phone Layout.
- Open a thread (it should be an active thread, just sort them by activity).
- Start closing the thread view by moving it to the right but not close it completely.
- Wait until thread updates.
- Once thread update arrives it crashes.