### PR TITLE
add ability to handle swf and some audio files

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
@@ -37,8 +37,7 @@ public class PostImage {
         GIF,
         MOVIE,
         PDF,
-        SWF,
-        MP3
+        SWF
     }
 
     public final String serverFilename;
@@ -76,6 +75,8 @@ public class PostImage {
                 break;
             case "webm":
             case "mp4":
+            case "mp3":
+            case "m4a":
                 type = MOVIE;
                 break;
             case "pdf":
@@ -83,9 +84,6 @@ public class PostImage {
                 break;
             case "swf":
                 type = Type.SWF;
-                break;
-            case "mp3":
-                type = Type.MP3;
                 break;
             default:
                 type = STATIC;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
@@ -77,6 +77,7 @@ public class PostImage {
             case "mp4":
             case "mp3":
             case "m4a":
+            case "flac":
                 type = MOVIE;
                 break;
             case "pdf":

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
@@ -77,6 +77,7 @@ public class PostImage {
             case "mp4":
             case "mp3":
             case "m4a":
+            case "ogg":
             case "flac":
                 type = MOVIE;
                 break;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
@@ -36,7 +36,9 @@ public class PostImage {
         STATIC,
         GIF,
         MOVIE,
-        PDF
+        PDF,
+        SWF,
+        MP3
     }
 
     public final String serverFilename;
@@ -78,6 +80,12 @@ public class PostImage {
                 break;
             case "pdf":
                 type = PDF;
+                break;
+            case "swf":
+                type = Type.SWF;
+                break;
+            case "mp3":
+                type = Type.MP3;
                 break;
             default:
                 type = STATIC;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
@@ -302,6 +302,10 @@ public class ImageViewerPresenter
                 callback.setImageMode(postImage, VIDEO, true);
             } else if (postImage.type == PDF) {
                 callback.setImageMode(postImage, OTHER, true);
+           } else if (postImage.type == SWF) {
+                callback.setImageMode(postImage, OTHER, true);
+            } else if (postImage.type == MP3) {
+                callback.setImageMode(postImage, OTHER, true);
             }
         }
 
@@ -488,6 +492,10 @@ public class ImageViewerPresenter
                 } else if (postImage.type == MOVIE && currentMode != VIDEO) {
                     callback.setImageMode(postImage, VIDEO, true);
                 } else if (postImage.type == PDF && currentMode != OTHER) {
+                    callback.setImageMode(postImage, OTHER, true);
+                } else if (postImage.type == SWF && currentMode != OTHER) {
+                    callback.setImageMode(postImage, OTHER, true);
+                } else if (postImage.type == MP3 && currentMode != OTHER) {
                     callback.setImageMode(postImage, OTHER, true);
                 } else {
                     if (callback.isImmersive()) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
@@ -304,8 +304,6 @@ public class ImageViewerPresenter
                 callback.setImageMode(postImage, OTHER, true);
             } else if (postImage.type == SWF) {
                 callback.setImageMode(postImage, OTHER, true);
-            } else if (postImage.type == MP3 && videoAutoLoad(loadable, postImage)) {
-                callback.setImageMode(postImage, VIDEO, true);
             }
         }
 
@@ -495,8 +493,6 @@ public class ImageViewerPresenter
                     callback.setImageMode(postImage, OTHER, true);
                 } else if (postImage.type == SWF && currentMode != OTHER) {
                     callback.setImageMode(postImage, OTHER, true);
-                } else if (postImage.type == MP3 && currentMode != VIDEO) {
-                    callback.setImageMode(postImage, VIDEO, true);
                 } else {
                     if (callback.isImmersive()) {
                         callback.showSystemUI(true);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
@@ -304,8 +304,8 @@ public class ImageViewerPresenter
                 callback.setImageMode(postImage, OTHER, true);
             } else if (postImage.type == SWF) {
                 callback.setImageMode(postImage, OTHER, true);
-            } else if (postImage.type == MP3) {
-                callback.setImageMode(postImage, OTHER, true);
+            } else if (postImage.type == MP3 && videoAutoLoad(loadable, postImage)) {
+                callback.setImageMode(postImage, VIDEO, true);
             }
         }
 
@@ -495,8 +495,8 @@ public class ImageViewerPresenter
                     callback.setImageMode(postImage, OTHER, true);
                 } else if (postImage.type == SWF && currentMode != OTHER) {
                     callback.setImageMode(postImage, OTHER, true);
-                } else if (postImage.type == MP3 && currentMode != OTHER) {
-                    callback.setImageMode(postImage, OTHER, true);
+                } else if (postImage.type == MP3 && currentMode != VIDEO) {
+                    callback.setImageMode(postImage, VIDEO, true);
                 } else {
                     if (callback.isImmersive()) {
                         callback.showSystemUI(true);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ImageViewerPresenter.java
@@ -302,7 +302,7 @@ public class ImageViewerPresenter
                 callback.setImageMode(postImage, VIDEO, true);
             } else if (postImage.type == PDF) {
                 callback.setImageMode(postImage, OTHER, true);
-           } else if (postImage.type == SWF) {
+            } else if (postImage.type == SWF) {
                 callback.setImageMode(postImage, OTHER, true);
             } else if (postImage.type == MP3) {
                 callback.setImageMode(postImage, OTHER, true);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
@@ -220,7 +220,8 @@ public class CommentParserHelper {
                     if (matcher.matches()) {
                         boolean noThumbnail =
                                 ((String) linkable.value).endsWith("webm") || ((String) linkable.value).endsWith("pdf")
-                                        || ((String) linkable.value).endsWith("mp4");
+                                        || ((String) linkable.value).endsWith("mp4") || ((String) linkable.value).endsWith("mp3")
+                                            || ((String) linkable.value).endsWith("swf");
                         String spoilerThumbnail =
                                 "https://raw.githubusercontent.com/Adamantcheese/Kuroba/multi-feature/docs/internal_spoiler.png";
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
@@ -73,7 +73,7 @@ public class CommentParserHelper {
     public static LruCache<String, String> youtubeDurCache = new LruCache<>(500);
 
     //@formatter:off
-    private static Pattern imageUrlPattern = Pattern.compile(".*/(.+?)\\.(jpg|png|jpeg|gif|webm|mp4|pdf|bmp|webp)", Pattern.CASE_INSENSITIVE);
+    private static Pattern imageUrlPattern = Pattern.compile(".*/(.+?)\\.(jpg|png|jpeg|gif|webm|mp4|pdf|bmp|webp|mp3|swf)", Pattern.CASE_INSENSITIVE);
     //@formatter:on
 
     private static final Pattern dubsPattern = Pattern.compile("(\\d)\\1$");

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
@@ -73,7 +73,7 @@ public class CommentParserHelper {
     public static LruCache<String, String> youtubeDurCache = new LruCache<>(500);
 
     //@formatter:off
-    private static Pattern imageUrlPattern = Pattern.compile(".*/(.+?)\\.(jpg|png|jpeg|gif|webm|mp4|pdf|bmp|webp|mp3|swf)", Pattern.CASE_INSENSITIVE);
+    private static Pattern imageUrlPattern = Pattern.compile(".*/(.+?)\\.(jpg|png|jpeg|gif|webm|mp4|pdf|bmp|webp|mp3|swf|m4a|ogg|flac)", Pattern.CASE_INSENSITIVE);
     //@formatter:on
 
     private static final Pattern dubsPattern = Pattern.compile("(\\d)\\1$");
@@ -221,7 +221,8 @@ public class CommentParserHelper {
                         boolean noThumbnail =
                                 ((String) linkable.value).endsWith("webm") || ((String) linkable.value).endsWith("pdf")
                                         || ((String) linkable.value).endsWith("mp4") || ((String) linkable.value).endsWith("mp3")
-                                            || ((String) linkable.value).endsWith("swf");
+                                            || ((String) linkable.value).endsWith("swf") || ((String) linkable.value).endsWith("m4a")
+                                                || ((String) linkable.value).endsWith("ogg") || ((String) linkable.value).endsWith("flac");
                         String spoilerThumbnail =
                                 "https://raw.githubusercontent.com/Adamantcheese/Kuroba/multi-feature/docs/internal_spoiler.png";
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/chan4/Chan4.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/chan4/Chan4.java
@@ -175,6 +175,7 @@ public class Chan4
         private final HttpUrl s = new HttpUrl.Builder().scheme("https").host("s.4cdn.org").build();
         private final HttpUrl sys = new HttpUrl.Builder().scheme("https").host("sys.4chan.org").build();
         private final HttpUrl b = new HttpUrl.Builder().scheme("https").host("boards.4chan.org").build();
+        private final HttpUrl swfthumb = new HttpUrl.Builder().scheme("https").host("www.abload.de").build();
 
         @Override
         public HttpUrl catalog(Board board) {
@@ -208,7 +209,14 @@ public class Chan4
                 }
                 return image.build();
             } else {
-                return t.newBuilder().addPathSegment(post.board.code).addPathSegment(arg.get("tim") + "s.jpg").build();
+                switch(arg.get("ext")) {
+                    case "swf":
+                        return swfthumb.newBuilder()
+                            .addPathSegment("/img/swfuhji6.png")
+                            .build();
+                    default:
+                        return t.newBuilder().addPathSegment(post.board.code).addPathSegment(arg.get("tim") + "s.jpg").build();
+                }
             }
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/chan4/Chan4BoardsRequest.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/chan4/Chan4BoardsRequest.java
@@ -31,8 +31,6 @@ import java.util.List;
 
 public class Chan4BoardsRequest
         extends JsonReaderRequest<List<Board>> {
-    public static List<String> BLOCKED = Collections.singletonList("f");
-
     private final Site site;
 
     public Chan4BoardsRequest(Site site, Listener<List<Board>> listener, ErrorListener errorListener) {
@@ -169,10 +167,6 @@ public class Chan4BoardsRequest
 
         if (board.hasMissingInfo()) {
             // Invalid data, ignore
-            return null;
-        }
-
-        if (BLOCKED.contains(board.code)) {
             return null;
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
@@ -659,9 +659,6 @@ public class MultiImageView
         } else if (image.type == PostImage.Type.SWF) {
             cancellableToast.showToast(R.string.swf_not_viewable);
             callback.onDownloaded(image);
-        } else if (image.type == PostImage.Type.MP3) {
-            cancellableToast.showToast(R.string.mp3_not_viewable);
-            callback.onDownloaded(image);
         }
     }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
@@ -656,6 +656,12 @@ public class MultiImageView
             cancellableToast.showToast(R.string.pdf_not_viewable);
             //this lets the user download the PDF, even though we haven't actually downloaded anything
             callback.onDownloaded(image);
+        } else if (image.type == PostImage.Type.SWF) {
+            cancellableToast.showToast(R.string.swf_not_viewable);
+            callback.onDownloaded(image);
+        } else if (image.type == PostImage.Type.MP3) {
+            cancellableToast.showToast(R.string.mp3_not_viewable);
+            callback.onDownloaded(image);
         }
     }
 

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -741,7 +741,6 @@ Don't have a 4chan Pass?<br>
     <string name="setting_youtube_dur_description">Adds duration parsing to Youtube titles; does not do anything with titles off</string>
     <string name="pdf_not_viewable">PDFs are not internally viewable; you can still download this file.</string>
     <string name="swf_not_viewable">SWFs are not internally viewable; you can still download this file.</string>
-    <string name="mp3_not_viewable">MP3s are not internally viewable; you can still download this file.</string>
     <string name="files_base_dir_does_not_exist"><![CDATA[Base directory for files does not exist! Set it manually in the settings (Media -> Save location)]]></string>
     <string name="local_threads_base_dir_does_not_exist"><![CDATA[Base directory for local threads does not exist! Set it manually in the settings (Media -> Local threads location). All active download has been stopped! Resume them manually after setting the base directory.]]></string>
     <string name="image_saver_could_not_figure_out_save_location">Couldn\'t figure out save location</string>

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -740,6 +740,8 @@ Don't have a 4chan Pass?<br>
     <string name="setting_youtube_dur_title">Enable Youtube durations</string>
     <string name="setting_youtube_dur_description">Adds duration parsing to Youtube titles; does not do anything with titles off</string>
     <string name="pdf_not_viewable">PDFs are not internally viewable; you can still download this file.</string>
+    <string name="swf_not_viewable">SWFs are not internally viewable; you can still download this file.</string>
+    <string name="mp3_not_viewable">MP3s are not internally viewable; you can still download this file.</string>
     <string name="files_base_dir_does_not_exist"><![CDATA[Base directory for files does not exist! Set it manually in the settings (Media -> Save location)]]></string>
     <string name="local_threads_base_dir_does_not_exist"><![CDATA[Base directory for local threads does not exist! Set it manually in the settings (Media -> Local threads location). All active download has been stopped! Resume them manually after setting the base directory.]]></string>
     <string name="image_saver_could_not_figure_out_save_location">Couldn\'t figure out save location</string>


### PR DESCRIPTION
based on 462029b
Neither swf nor mp3's can be handled internally but still be downloaded.

Goes hand in hand with 420chan's /m/ & /f/ boards which support uploading these file types.
Surely there are other imageboards out there which support them aswell.