### PR TITLE
Bunch of fixes and improvements related to SAF/FSAF, image loading etc

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:1.0-alpha28'
+    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha36'
     implementation 'joda-time:joda-time:2.10.5'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha36'
+    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha38'
     implementation 'joda-time:joda-time:2.10.5'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/ThreadSaveManager.java
@@ -697,6 +697,7 @@ public class ThreadSaveManager {
         for (Post post : newPosts) {
             for (PostImage postImage : post.images) {
                 if (postImage.isInlined) {
+                    // Skip inlined files
                     continue;
                 }
 
@@ -780,6 +781,11 @@ public class ThreadSaveManager {
             BaseFileManager snapshotFileManager, AbstractFile threadSaveDirImages, Post post
     ) {
         for (PostImage postImage : post.images) {
+            if (postImage.isInlined) {
+                // Skip inlined files
+                continue;
+            }
+
             {
                 String originalImageFilename =
                         postImage.serverFilename + "_" + ORIGINAL_FILE_NAME + "." + postImage.extension;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/PostImage.java
@@ -49,6 +49,7 @@ public class PostImage {
     public final int imageWidth;
     public final int imageHeight;
     public final boolean spoiler;
+    public final boolean isInlined;
     public final long size;
     @Nullable
     public final String fileHash;
@@ -65,6 +66,7 @@ public class PostImage {
         this.imageWidth = builder.imageWidth;
         this.imageHeight = builder.imageHeight;
         this.spoiler = builder.spoiler;
+        this.isInlined = builder.isInlined;
         this.size = builder.size;
         this.fileHash = builder.fileHash;
 
@@ -111,6 +113,7 @@ public class PostImage {
         private int imageWidth;
         private int imageHeight;
         private boolean spoiler;
+        private boolean isInlined = false;
         private long size;
         @Nullable
         private String fileHash;
@@ -164,6 +167,11 @@ public class PostImage {
 
         public Builder spoiler(boolean spoiler) {
             this.spoiler = spoiler;
+            return this;
+        }
+
+        public Builder isInlined(boolean inlined) {
+            this.isInlined = inlined;
             return this;
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
@@ -267,8 +267,8 @@ public class ChanSettings {
     public static final BooleanSetting imageViewerGestures;
     public static final BooleanSetting allowFilePickChooser;
     public static final BooleanSetting autoCrashLogsUpload;
-
     public static final BooleanSetting captchaOnBottom;
+    public static final BooleanSetting showCopyApkUpdateDialog;
 
     static {
         try {
@@ -414,6 +414,7 @@ public class ChanSettings {
             allowFilePickChooser = new BooleanSetting(p, "allow_file_picker_chooser", false);
             autoCrashLogsUpload = new BooleanSetting(p, "auto_upload_crash_logs", true);
             captchaOnBottom = new BooleanSetting(p, "captcha_on_bottom", true);
+            showCopyApkUpdateDialog = new BooleanSetting(p, "show_copy_apk_update_dialog", true);
         } catch (Throwable error) {
             // If something crashes while the settings are initializing we at least will have the
             // stacktrace. Otherwise we won't because of the Feather.

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/CommentParserHelper.java
@@ -238,6 +238,7 @@ public class CommentParserHelper {
                                 .filename(matcher.group(1))
                                 .extension(matcher.group(2))
                                 .spoiler(true)
+                                .isInlined(true)
                                 .size(-1)
                                 .build()));
                     }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
@@ -268,6 +268,12 @@ public class AlbumDownloadController
         this.loadable = loadable;
         for (int i = 0, postImagesSize = postImages.size(); i < postImagesSize; i++) {
             PostImage postImage = postImages.get(i);
+            if (postImage.isInlined) {
+                // Do not allow downloading inlined files via the Album downloads (because they often
+                // fail with SSL exceptions) and we can't really trust those files.
+                continue;
+            }
+
             items.add(new AlbumDownloadItem(postImage, true, i));
         }
     }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
@@ -41,6 +41,7 @@ import com.github.adamantcheese.chan.ui.theme.ThemeHelper;
 import com.github.adamantcheese.chan.ui.toolbar.ToolbarMenuItem;
 import com.github.adamantcheese.chan.ui.view.GridRecyclerView;
 import com.github.adamantcheese.chan.ui.view.PostImageThumbnailView;
+import com.github.adamantcheese.chan.utils.BackgroundUtils;
 import com.github.adamantcheese.chan.utils.RecyclerUtils;
 import com.github.adamantcheese.chan.utils.StringUtils;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -50,6 +51,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
 
 import static com.github.adamantcheese.chan.Chan.inject;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.dp;
@@ -73,6 +78,7 @@ public class AlbumDownloadController
     @Inject
     ImageSaver imageSaver;
 
+    private CompositeDisposable compositeDisposable;
     private boolean allChecked = true;
 
     public AlbumDownloadController(Context context) {
@@ -103,11 +109,13 @@ public class AlbumDownloadController
         recyclerView.setAdapter(adapter);
 
         imageSaver.setBundledTaskCallback(this);
+        compositeDisposable = new CompositeDisposable();
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
+        compositeDisposable.dispose();
         imageSaver.removeBundleTaskCallback();
     }
 
@@ -141,6 +149,12 @@ public class AlbumDownloadController
                 //generate tasks before prompting
                 List<ImageSaveTask> tasks = new ArrayList<>(items.size());
                 for (AlbumDownloadItem item : items) {
+                    if (item.postImage.isInlined) {
+                        // Do not download inlined files via the Album downloads (because they often
+                        // fail with SSL exceptions) and we can't really trust those files.
+                        continue;
+                    }
+
                     if (item.checked) {
                         ImageSaveTask imageTask = new ImageSaveTask(loadable, item.postImage, true);
                         if (subFolder != null) {
@@ -152,36 +166,52 @@ public class AlbumDownloadController
 
                 new AlertDialog.Builder(context).setMessage(message)
                         .setNegativeButton(R.string.cancel, null)
-                        .setPositiveButton(R.string.ok, (dialog, which) -> handleDownloadResult(tasks))
+                        .setPositiveButton(R.string.ok, (dialog, which) -> startAlbumDownloadTask(tasks))
                         .show();
             }
         }
     }
 
-    private void handleDownloadResult(List<ImageSaveTask> tasks) {
-        ImageSaver.BundledImageSaveResult result = imageSaver.startBundledTask(context, tasks);
+    private void startAlbumDownloadTask(List<ImageSaveTask> tasks) {
+        showLoadingView();
+
+        Disposable disposable = imageSaver.startBundledTask(context, tasks)
+                .observeOn(AndroidSchedulers.mainThread())
+                .onErrorReturnItem(ImageSaver.BundledImageSaveResult.UnknownError)
+                .subscribe(this::onResultEvent);
+
+        compositeDisposable.add(disposable);
+    }
+
+    private void onResultEvent(ImageSaver.BundledImageSaveResult result) {
+        BackgroundUtils.ensureMainThread();
+
+        if (result == ImageSaver.BundledImageSaveResult.Ok) {
+            // Do nothing, we got the permissions and started downloading an album
+            return;
+        }
 
         switch (result) {
-            case Ok:
-                if (loadingViewController != null) {
-                    loadingViewController.stopPresenting();
-                }
-
-                loadingViewController = new LoadingViewController(context, false);
-                loadingViewController.enableBack();
-                navigationController.presentController(loadingViewController);
-                break;
             case BaseDirectoryDoesNotExist:
                 showToast(context, R.string.files_base_dir_does_not_exist);
+                break;
+            case NoWriteExternalStoragePermission:
+                showToast(context, R.string.could_not_start_saving_no_permissions);
                 break;
             case UnknownError:
                 showToast(context, R.string.album_download_could_not_save_one_or_more_images);
                 break;
         }
+
+        // Only hide in case of an error. If everything is fine the loading view will be hidden when
+        // onBundleDownloadCompleted() is called
+        hideLoadingView();
     }
 
     @Override
     public void onImageProcessed(int downloaded, int failed, int total) {
+        BackgroundUtils.ensureMainThread();
+
         if (loadingViewController != null) {
             String message =
                     getString(R.string.album_download_batch_image_processed_message, downloaded, total, failed);
@@ -192,13 +222,29 @@ public class AlbumDownloadController
 
     @Override
     public void onBundleDownloadCompleted() {
+        BackgroundUtils.ensureMainThread();
+        hideLoadingView();
+
+        //extra pop to get out of this controller
+        navigationController.popController();
+    }
+
+    private void hideLoadingView() {
+        BackgroundUtils.ensureMainThread();
+
         if (loadingViewController != null) {
             loadingViewController.stopPresenting();
             loadingViewController = null;
         }
+    }
 
-        //extra pop to get out of this controller
-        navigationController.popController();
+    private void showLoadingView() {
+        BackgroundUtils.ensureMainThread();
+        hideLoadingView();
+
+        loadingViewController = new LoadingViewController(context, false);
+        loadingViewController.enableBack();
+        navigationController.presentController(loadingViewController);
     }
 
     private void onCheckAllClicked(ToolbarMenuItem menuItem) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/BehaviourSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/BehaviourSettingsController.java
@@ -200,6 +200,12 @@ public class BehaviourSettingsController
                     R.string.settings_allow_media_scanner_scan_local_threads_description
             ));
 
+            other.add(new BooleanSettingView(this,
+                    ChanSettings.showCopyApkUpdateDialog,
+                    R.string.settings_show_copy_apk_dialog_title,
+                    R.string.settings_show_copy_apk_dialog_message
+            ));
+
             groups.add(other);
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/base_directory/SharedLocationSetupDelegate.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/base_directory/SharedLocationSetupDelegate.kt
@@ -41,7 +41,7 @@ class SharedLocationSetupDelegate(
         val isNewBaseDirExternal = newBaseDirectory is ExternalFile
 
         if (isOldBaseDirExternal xor isNewBaseDirExternal) {
-            // oldBaseDirectory and newBaseDirectory do not use the same provider (one of the uses a
+            // oldBaseDirectory and newBaseDirectory do not use the same provider (one of them uses a
             // RawFile and the other one uses ExternalFile). It's kinda hard to determine whether
             // they are the same directory or whether one is a parent of the other. So we are just
             // not gonna do in such case.
@@ -91,7 +91,7 @@ class SharedLocationSetupDelegate(
         val isNewBaseDirExternal = newBaseDirectory is ExternalFile
 
         if (isOldBaseDirExternal xor isNewBaseDirExternal) {
-            // oldBaseDirectory and newBaseDirectory do not use the same provider (one of the uses a
+            // oldBaseDirectory and newBaseDirectory do not use the same provider (one of them uses a
             // RawFile and the other one uses ExternalFile). It's kinda hard to determine whether
             // they are the same directory or whether one is a parent of the other. So we are just
             // not gonna do in such case.

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/StringUtils.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/StringUtils.java
@@ -12,6 +12,9 @@ import java.util.regex.Pattern;
 public class StringUtils {
     private static final Pattern IMAGE_THUMBNAIL_EXTRACTOR_PATTERN = Pattern.compile("/(\\d{12,32}+)s.(.*)");
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toLowerCase(Locale.US).toCharArray();
+    private static final String RESERVED_CHARACTERS = "|?*<\":>+\\[\\]/'\\\\\\s";
+    private static final String RESERVED_CHARACTERS_DIR = "[" + RESERVED_CHARACTERS + "." + "]";
+    private static final String RESERVED_CHARACTERS_FILE = "[" + RESERVED_CHARACTERS + "]";
 
     public static String bytesToHex(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];
@@ -67,14 +70,14 @@ public class StringUtils {
     }
 
     public static String dirNameRemoveBadCharacters(String dirName) {
-        return dirName.replaceAll(" ", "_").replaceAll("[^a-zA-Z0-9_-]", "");
+        return dirName.replaceAll(" ", "_").replaceAll(RESERVED_CHARACTERS_DIR, "");
     }
 
     /**
      * The same as dirNameRemoveBadCharacters but allows dots since file names can have extensions
      */
     public static String fileNameRemoveBadCharacters(String filename) {
-        return filename.replaceAll(" ", "_").replaceAll("[^a-zA-Z0-9_.-]", "");
+        return filename.replaceAll(" ", "_").replaceAll(RESERVED_CHARACTERS_FILE, "");
     }
 
     @Nullable

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="create">Create</string>
     <string name="do_not">Do not</string>
     <string name="move">Move</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
 
     <string name="permission_app_settings">App settings</string>
     <string name="permission_grant">Grant</string>
@@ -796,4 +798,11 @@ Don't have a 4chan Pass?<br>
 
     <string name="site_uses_dynamic_boards">"Unable to go to board (site likely has dynamic boards). Add the board using the boards menu first."</string>
     <string name="could_not_start_saving_no_permissions">Could not start downloading images, no WRITE_ACCESS permission was granted</string>
+    <string name="update_manager_copy_apk_title">Copy apk?</string>
+    <string name="update_manager_copy_apk_message">Would you like to store this apk?</string>
+    <string name="update_manager_could_not_convert_uri">Couldn\'t convert uri (%1$s) into an ExternalFile</string>
+    <string name="update_manager_input_file_does_not_exist">Input apk file (%1$s) does not exist</string>
+    <string name="update_manager_output_file_does_not_exist">Output file (%1$s) does not exist</string>
+    <string name="update_manager_could_not_copy_apk">Couldn\'t copy file contents from file (%1$s) into (%2$s)</string>
+    <string name="update_manager_apk_copied">Apk successfully copied</string>
 </resources>

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -354,7 +354,6 @@ Note that for country code filtering, troll country codes should be prepended wi
     <string name="image_save_notification_cancel">Tap to cancel</string>
     <string name="image_save_saved">Image saved</string>
     <string name="image_saver_saved_as_message">Saved as \"%1$s\"</string>
-    <string name="image_saver_failed_to_save_image_message">Saving image failed</string>
 
     <string name="thread_page_limit">Thread hit last page</string>
 
@@ -796,4 +795,5 @@ Don't have a 4chan Pass?<br>
     <string name="media_settings_could_not_create_default_baseDir">Could not create default base dir: %1$s</string>
 
     <string name="site_uses_dynamic_boards">"Unable to go to board (site likely has dynamic boards). Add the board using the boards menu first."</string>
+    <string name="could_not_start_saving_no_permissions">Could not start downloading images, no WRITE_ACCESS permission was granted</string>
 </resources>

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -805,4 +805,6 @@ Don't have a 4chan Pass?<br>
     <string name="update_manager_output_file_does_not_exist">Output file (%1$s) does not exist</string>
     <string name="update_manager_could_not_copy_apk">Couldn\'t copy file contents from file (%1$s) into (%2$s)</string>
     <string name="update_manager_apk_copied">Apk successfully copied</string>
+    <string name="settings_show_copy_apk_dialog_title">Show copy apk dialog when downloading an update</string>
+    <string name="settings_show_copy_apk_dialog_message">Every time you download a new update a dialog with suggestion to copy that apk to some other directory will be shown</string>
 </resources>

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/utils/StringUtilsTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/utils/StringUtilsTest.kt
@@ -1,0 +1,24 @@
+package com.github.adamantcheese.chan.utils
+
+import junit.framework.Assert.assertEquals
+import org.junit.Test
+
+class StringUtilsTest {
+
+    @Test
+    fun `test dirNameRemoveBadCharacters`() {
+        val testString = "123abcабв. [|?*<\":>+\\[\\]/']\n\r"
+        val expectedString = "123abcабв_"
+
+        assertEquals(expectedString, StringUtils.dirNameRemoveBadCharacters(testString))
+    }
+
+    @Test
+    fun `test fileNameRemoveBadCharacters`() {
+        val testString = "123abcабв.txt [|?*<\":>+\\[\\]/']\n\r"
+        val expectedString = "123abcабв.txt_"
+
+        assertEquals(expectedString, StringUtils.fileNameRemoveBadCharacters(testString))
+    }
+
+}


### PR DESCRIPTION
Closes #694, #687, #638, #579, #703 
Maybe closes #696, #690, #560

- Update FSAF to v1.0-alpha36. (Snapshots have been reworked, a bug related to snapshots has been fixed (now we shouldn't see bugs where files or directories cannot be created for some unknown reason),
some changes to clone() methods, flattenSegments() implementation, get rid of cloneUnsafe() in Kuroba and some other changes).
- Move handleLocalThreadFile() method call to a background thread to avoid micro freezes when swiping images in a local thread.
- Do not download inlined files for local threads (inlined files now have isInlined flag set to true, it's false by default and only being set in one place - where we parse them).
- Use new Snapshots in ThreadSaveManager.
- Try to create default base directories, if they weren't set by the user and do not exist, when trying to download an image or an album.
- A little bit of optimization for getSaveLocation(). First of all, it won't be called twice now. Second, it will return a flattened AbstractFile (no intermediate segments).
- Fix MissingBackpressureException when downloading thread albums.
- Fix app freezing (and depending on how many images in a thread even ANRing) when downloading thread albums. Because we need to check a lot of stuff before downloading an album (like create all the necessary directories, deduplicate the file name, etc).
- Relax directory and file name filtering rules. Previous regex was really strict, so if an image contained any non-english letters, they would all be replaced with _ which is a big problem for
non-english image boards (almost every image name would contain lots of _ symbols and it could even cause collisions). Now it only filters out special symbols and periods (only in directory names). Everything else is allowed.
- Do not download inlined files when downloading thread albums. Some of the hosts are bad and cause SSL exceptions and other stuff. Also, inlined files may be really big and we can't check how big they are unless we download them first.
- Fix bugs related to not being able to move files from an old base directory to a new one when both of them are using the same file provider (update FSAF to v1.0-alpha38)