### PR TITLE
Fix an old thread downloading bug

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/WatchManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/WatchManager.java
@@ -388,6 +388,7 @@ public class WatchManager
 
         destroyPinWatcher(pin);
         deleteSavedThread(pin.loadable.id);
+        pin.loadable.loadableDownloadingState = Loadable.LoadableDownloadingState.NotDownloading;
 
         threadSaveManager.cancelDownloading(pin.loadable);
 


### PR DESCRIPTION
Fix a bug when removing a pin with a downloading thread by swiping it away in the drawer would not set the pin's loadable loadableDownloadingState to NotDownloading which would result in not being able to open any images until the app restart because we would try to load images from the disk (since the loadable has isLocal() == true)