### PR TITLE
(#730) Request FLAG_GRANT_READ_URI_PERMISSION when using alternative file pickers

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/helper/ImagePickDelegate.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/helper/ImagePickDelegate.java
@@ -118,6 +118,7 @@ public class ImagePickDelegate {
             Intent newIntent = new Intent(Intent.ACTION_GET_CONTENT);
             newIntent.addCategory(Intent.CATEGORY_OPENABLE);
             newIntent.setPackage(info.activityInfo.packageName);
+            newIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             newIntent.setType("*/*");
 
             intents.add(newIntent);


### PR DESCRIPTION
Closes #730