### PR TITLE
Update FSAF + fix handle local thread json parsing exception in another place

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -249,7 +249,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     //noinspection GradleDependency wants to upgrade to older version
-    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha38'
+    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha39'
     implementation 'joda-time:joda-time:2.10.5'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -249,7 +249,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     //noinspection GradleDependency wants to upgrade to older version
-    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha39'
+    implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha40'
     implementation 'joda-time:joda-time:2.10.5'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/repository/SavedThreadLoaderRepository.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/repository/SavedThreadLoaderRepository.kt
@@ -36,7 +36,6 @@ constructor(
         BackgroundUtils.ensureBackgroundThread()
 
         val threadFile = threadSaveDir.clone(FileSegment(THREAD_FILE_NAME))
-
         if (!fileManager.exists(threadFile)) {
             Logger.d(TAG, "threadFile does not exist, threadFilePath = " + threadFile.getFullPath())
             return null

--- a/Kuroba/app/src/main/res/layout/layout_thread_error.xml
+++ b/Kuroba/app/src/main/res/layout/layout_thread_error.xml
@@ -22,9 +22,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <TextView
         android:id="@+id/text"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:gravity="center"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:textSize="24sp" />
 

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -809,4 +809,5 @@ Don't have a 4chan Pass?<br>
     <string name="update_manager_apk_copied">Apk successfully copied</string>
     <string name="settings_show_copy_apk_dialog_title">Show copy apk dialog when downloading an update</string>
     <string name="settings_show_copy_apk_dialog_message">Every time you download a new update a dialog with suggestion to copy that apk to some other directory will be shown</string>
+    <string name="thread_load_failed_local_thread_parsing">Error while trying to parse local thread json file. Try deleting and the re-downloading the thread to fix this error.</string>
 </resources>


### PR DESCRIPTION
Closes #714, #772 and couple of more fixes for #720 and more logs to fix this #638 issue (again) (I kinda have a hunch why this thing happens but need confirmation)

- Update FSAF to v1.0-alpha39 which has couple of fixes related to files listed in a directory and file containing more than one period at the end of it.
- Local thread json parsing exception was not handled in all places where it could be called. Now it should be handled in all places and the error should be propagated down to the ThreadPresenter where we will show it instead of infinite spinner.
- Use default external storage dir path when couldn't figure out where the initial position of SaveLocationController should be.