### PR TITLE
(#781) Filter out InterruptedExceptions coming into RxJava onError handler inside RuntimeExceptions

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/Chan.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/Chan.java
@@ -140,6 +140,11 @@ public class Chan
                 // fine, some blocking code was interrupted by a dispose call
                 return;
             }
+            if (e instanceof RuntimeException && e.getCause() instanceof InterruptedException) {
+                // fine, DB synchronous call (via runTask) was interrupted when a reactive stream
+                // was disposed of.
+                return;
+            }
             if (e instanceof FileCacheException.CancellationException
                     || e instanceof FileCacheException.FileNotFoundOnTheServerException) {
                 // fine, sometimes they get through all the checks but it doesn't really matter

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/database/DatabaseManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/database/DatabaseManager.java
@@ -207,7 +207,12 @@ public class DatabaseManager {
     public <T> T runTask(final Callable<T> taskCallable) {
         try {
             return executeTask(taskCallable, null).get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            // Since we don't rethrow InterruptedException we need to at least restore the
+            // "interrupted" flag.
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Closes #781

When you dispose of RxJava reactive stream it interrupts whatever blocking operation current running so they throw InterruptedException. If it so happens that we do a sync DB call via runTask() inside
RxJava stream and it gets terminated runTask will throw a RuntimeException with InterruptedException inside it.