### PR TITLE
Handle strange crashes with the following message: java.lang.IllegalStateException: Failed to touch ***.jpg: java.io.IOException: Read-only file system

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaveTask.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/saver/ImageSaveTask.java
@@ -213,8 +213,13 @@ public class ImageSaveTask
             }
 
             result = true;
-        } catch (IOException e) {
-            Logger.e(TAG, "Error writing to file", e);
+        } catch (Throwable e) {
+            boolean exists = fileManager.exists(destination);
+            boolean canWrite = fileManager.canWrite(destination);
+
+            Logger.e(TAG,
+                    "Error writing to file: (" + destination.getFullPath() + "), " +
+                            "exists = " + exists + ", canWrite = " + canWrite, e);
         }
 
         return result;


### PR DESCRIPTION
Still have no idea what's causing them. At least the app won't crash now.