### PR TITLE
(#800) Use MResult to pass a result downstream instead of throwing an exception (+ couple of other improvements)

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/base/MFunc.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/base/MFunc.kt
@@ -1,0 +1,17 @@
+package com.github.adamantcheese.chan.core.base
+
+interface MFunc {
+    fun invoke()
+}
+
+interface MFuncT<T> {
+    fun invoke(param: T)
+}
+
+interface MFuncR<R> {
+    fun invoke(): R
+}
+
+interface MFuncTR<T, R> {
+    fun invoke(param: T): R
+}

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/base/MResult.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/base/MResult.kt
@@ -4,13 +4,70 @@ sealed class MResult<V> {
     data class Value<V>(val value: V) : MResult<V>()
     data class Error<V>(val error: Throwable) : MResult<V>()
 
+    fun isError() = this is Error
+    fun isValue() = this is Value
+
+    fun valueOrNull(): V? {
+        if (this is Value) {
+            return value
+        }
+
+        return null
+    }
+
+    fun errorOrNull(): Throwable? {
+        if (this is Error) {
+            return error
+        }
+
+        return null
+    }
+
+    inline fun map(func: (value: V) -> V): MResult<V> {
+        if (isError()) {
+            return this
+        }
+
+        return safeRun { func(valueOrNull()!!) }
+    }
+
     companion object {
+        @JvmStatic
         fun <V> value(value: V): MResult<V> {
             return Value(value)
         }
 
+        @JvmStatic
         fun <V> error(error: Throwable): MResult<V> {
             return Error(error)
+        }
+
+        inline fun <T> safeRun(func: () -> T): MResult <T> {
+            return try {
+                value(func())
+            } catch (error: Throwable) {
+                error(error)
+            }
+        }
+
+        // These two are for calling from the Java code since it's not really convenient to use
+        // kotlin's lambdas in Java code.
+        @JvmStatic
+        fun safeRun(func: MFunc): MResult<Unit> {
+            return try {
+                value(func.invoke())
+            } catch (error: Throwable) {
+                error(error)
+            }
+        }
+
+        @JvmStatic
+        fun <T> safeRunR(func: MFuncR<T>): MResult<T> {
+            return try {
+                value(func.invoke())
+            } catch (error: Throwable) {
+                error(error)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #800 