### PR TITLE
Bring back text item buttons (spoiler, code, etc.) in reply layout

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ReplyPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ReplyPresenter.java
@@ -184,6 +184,20 @@ public class ReplyPresenter
                 callback.openSpoiler(moreOpen, false);
             }
         }
+        callback.openCommentQuoteButton(moreOpen);
+        if (board.spoilers) {
+            callback.openCommentSpoilerButton(moreOpen);
+        }
+        if (board.site.name().equals("4chan") && board.code.equals("g")) {
+            callback.openCommentCodeButton(moreOpen);
+        }
+        if (board.site.name().equals("4chan") && board.code.equals("sci")) {
+            callback.openCommentEqnButton(moreOpen);
+            callback.openCommentMathButton(moreOpen);
+        }
+        if (board.site.name().equals("4chan") && (board.code.equals("jp") || board.code.equals("vip"))) {
+            callback.openCommentSJISButton(moreOpen);
+        }
     }
 
     public boolean isExpanded() {
@@ -488,6 +502,12 @@ public class ReplyPresenter
         callback.openMessage(false, true, "", false);
         callback.setExpanded(false);
         callback.openSubject(false);
+        callback.openCommentQuoteButton(false);
+        callback.openCommentSpoilerButton(false);
+        callback.openCommentCodeButton(false);
+        callback.openCommentEqnButton(false);
+        callback.openCommentMathButton(false);
+        callback.openCommentSJISButton(false);
         callback.openNameOptions(false);
         callback.openFileName(false);
         callback.openSpoiler(false, false);
@@ -631,6 +651,18 @@ public class ReplyPresenter
         void openNameOptions(boolean open);
 
         void openSubject(boolean open);
+
+        void openCommentQuoteButton(boolean open);
+
+        void openCommentSpoilerButton(boolean open);
+
+        void openCommentCodeButton(boolean open);
+
+        void openCommentEqnButton(boolean open);
+
+        void openCommentMathButton(boolean open);
+
+        void openCommentSJISButton(boolean open);
 
         void openFileName(boolean open);
 

--- a/Kuroba/app/src/main/res/layout/layout_reply_input.xml
+++ b/Kuroba/app/src/main/res/layout/layout_reply_input.xml
@@ -121,6 +121,94 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
             </RelativeLayout>
 
+            <LinearLayout
+                android:id="@+id/comment_buttons"
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                tools:ignore="SpUsage">
+
+                <Button
+                    android:id="@+id/comment_quote"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_margin="0dp"
+                    android:padding="0dp"
+                    android:text="@string/reply_comment_button_quote"
+                    android:textAllCaps="false"
+                    android:textSize="15dp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <Button
+                    android:id="@+id/comment_spoiler"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_margin="0dp"
+                    android:padding="0dp"
+                    android:text="@string/reply_comment_button_spoiler_tag"
+                    android:textAllCaps="false"
+                    android:textSize="15dp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <Button
+                    android:id="@+id/comment_code"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_margin="0dp"
+                    android:padding="0dp"
+                    android:text="@string/reply_comment_button_code_tag"
+                    android:textAllCaps="false"
+                    android:textSize="15dp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <Button
+                    android:id="@+id/comment_eqn"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_margin="0dp"
+                    android:padding="0dp"
+                    android:text="@string/reply_comment_button_eqn_tag"
+                    android:textAllCaps="false"
+                    android:textSize="15dp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <Button
+                    android:id="@+id/comment_math"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="50dp"
+                    android:layout_height="40dp"
+                    android:layout_margin="0dp"
+                    android:padding="0dp"
+                    android:text="@string/reply_comment_button_math_tag"
+                    android:textAllCaps="false"
+                    android:textSize="15dp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <Button
+                    android:id="@+id/comment_sjis"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="50dp"
+                    android:layout_height="40dp"
+                    android:layout_margin="0dp"
+                    android:padding="0dp"
+                    android:text="@string/reply_comment_button_sjis_tag"
+                    android:textAllCaps="false"
+                    android:textSize="15dp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+            </LinearLayout>
+
             <CheckBox
                 android:id="@+id/spoiler"
                 android:layout_width="match_parent"

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -338,6 +338,12 @@ Note that for country code filtering, troll country codes should be prepended wi
     <string name="reply_comment_button_math">Math</string>
     <string name="reply_comment_button_sjis">SJIS</string>
 
+    <string name="reply_comment_button_spoiler_tag">[s]</string>
+    <string name="reply_comment_button_code_tag">[c]</string>
+    <string name="reply_comment_button_eqn_tag">[eqn]</string>
+    <string name="reply_comment_button_math_tag">[math]</string>
+    <string name="reply_comment_button_sjis_tag">[sjis]</string>
+
     <string name="delete_confirm">Delete your post?</string>
     <string name="delete_wait">Deleting post…</string>
     <string name="delete_success">Post deleted</string>


### PR DESCRIPTION
This returns the text item buttons to the expanded reply layout for the people whose phones don't support the context menu options for some reason or other.