### PR TITLE
(#820) Add option to choose flag in reply layout

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ReplyPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ReplyPresenter.java
@@ -199,6 +199,9 @@ public class ReplyPresenter
         if (is4chan && (board.code.equals("jp") || board.code.equals("vip"))) {
             callback.openCommentSJISButton(moreOpen);
         }
+        if (is4chan && board.code.equals("pol")) {
+            callback.openFlag(moreOpen);
+        }
     }
 
     public boolean isExpanded() {
@@ -503,6 +506,7 @@ public class ReplyPresenter
         callback.openMessage(false, true, "", false);
         callback.setExpanded(false);
         callback.openSubject(false);
+        callback.openFlag(false);
         callback.openCommentQuoteButton(false);
         callback.openCommentSpoilerButton(false);
         callback.openCommentCodeButton(false);
@@ -652,6 +656,8 @@ public class ReplyPresenter
         void openNameOptions(boolean open);
 
         void openSubject(boolean open);
+
+        void openFlag(boolean open);
 
         void openCommentQuoteButton(boolean open);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/http/Reply.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/http/Reply.java
@@ -40,6 +40,7 @@ public class Reply {
     public String fileName = "";
     public String name = "";
     public String options = "";
+    public String flag = "";
     public String subject = "";
     public String comment = "";
     public int selectionStart;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/chan4/Chan4ReplyCall.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/chan4/Chan4ReplyCall.java
@@ -65,7 +65,11 @@ public class Chan4ReplyCall
         }
 
         if (site instanceof Chan4 && reply.loadable.boardCode.equals("pol")) {
-            formBuilder.addFormDataPart("flag", Chan4.flagType.get());
+            if (!reply.flag.isEmpty()) {
+                formBuilder.addFormDataPart("flag", reply.flag);
+            } else {
+                formBuilder.addFormDataPart("flag", Chan4.flagType.get());
+            }
         }
 
         if (reply.file != null) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
@@ -121,6 +121,7 @@ public class ReplyLayout
     private TextView message;
     private EditText name;
     private EditText subject;
+    private EditText flag;
     private EditText options;
     private EditText fileName;
     private LinearLayout nameOptions;
@@ -196,6 +197,7 @@ public class ReplyLayout
         message = replyInputLayout.findViewById(R.id.message);
         name = replyInputLayout.findViewById(R.id.name);
         subject = replyInputLayout.findViewById(R.id.subject);
+        flag = replyInputLayout.findViewById(R.id.flag);
         options = replyInputLayout.findViewById(R.id.options);
         fileName = replyInputLayout.findViewById(R.id.file_name);
         nameOptions = replyInputLayout.findViewById(R.id.name_options);
@@ -541,6 +543,7 @@ public class ReplyLayout
     public void loadDraftIntoViews(Reply draft) {
         name.setText(draft.name);
         subject.setText(draft.subject);
+        flag.setText(draft.flag);
         options.setText(draft.options);
         blockSelectionChange = true;
         comment.setText(draft.comment);
@@ -554,6 +557,7 @@ public class ReplyLayout
     public void loadViewsIntoDraft(Reply draft) {
         draft.name = name.getText().toString();
         draft.subject = subject.getText().toString();
+        draft.flag = flag.getText().toString();
         draft.options = options.getText().toString();
         draft.comment = comment.getText().toString();
         draft.selectionStart = comment.getSelectionStart();
@@ -629,9 +633,10 @@ public class ReplyLayout
     }
 
     @Override
-    public void openSubject(boolean open) {
-        subject.setVisibility(open ? VISIBLE : GONE);
-    }
+    public void openSubject(boolean open) { subject.setVisibility(open ? VISIBLE : GONE); }
+
+    @Override
+    public void openFlag(boolean open) { flag.setVisibility(open ? VISIBLE : GONE); }
 
     @Override
     public void openCommentQuoteButton(boolean open) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
@@ -633,10 +633,14 @@ public class ReplyLayout
     }
 
     @Override
-    public void openSubject(boolean open) { subject.setVisibility(open ? VISIBLE : GONE); }
+    public void openSubject(boolean open) {
+        subject.setVisibility(open ? VISIBLE : GONE);
+    }
 
     @Override
-    public void openFlag(boolean open) { flag.setVisibility(open ? VISIBLE : GONE); }
+    public void openFlag(boolean open) {
+        flag.setVisibility(open ? VISIBLE : GONE);
+    }
 
     @Override
     public void openCommentQuoteButton(boolean open) {

--- a/Kuroba/app/src/main/res/layout/layout_reply_input.xml
+++ b/Kuroba/app/src/main/res/layout/layout_reply_input.xml
@@ -72,6 +72,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     android:textSize="16sp" />
 
                 <EditText
+                    android:id="@+id/flag"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="Flag"
+                    android:singleLine="true"
+                    android:textSize="16sp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <EditText
                     android:id="@+id/options"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
A quick and simple fix to #820 which adds the flag code option to the reply layout to make changing flags easier. Ultimately a dropdown menu with all the available flags would be a better option, maybe I'll have a look at implementing that sometime in the future.