### PR TITLE
Fix invisible divider in gruvbox theme

### DIFF
--- a/Kuroba/app/src/main/res/values/styles.xml
+++ b/Kuroba/app/src/main/res/values/styles.xml
@@ -251,9 +251,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="post_highlighted_color">#3c3836</item>
         <item name="post_selected_color">#3c3836</item>
 
-<!--        <item name="divider_color">#00FFFFFF</item>-->
-<!--        <item name="divider_split_color">#ebdbb2</item>-->
-
         <item name="dropdown_dark_color">#ffffff</item>
         <item name="dropdown_dark_pressed_color">#ffffff</item>
     </style>

--- a/Kuroba/app/src/main/res/values/styles.xml
+++ b/Kuroba/app/src/main/res/values/styles.xml
@@ -251,8 +251,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="post_highlighted_color">#3c3836</item>
         <item name="post_selected_color">#3c3836</item>
 
-        <item name="divider_color">#3c3836</item>
-        <item name="divider_split_color">#3c3836</item>
+<!--        <item name="divider_color">#00FFFFFF</item>-->
+<!--        <item name="divider_split_color">#ebdbb2</item>-->
 
         <item name="dropdown_dark_color">#ffffff</item>
         <item name="dropdown_dark_pressed_color">#ffffff</item>


### PR DESCRIPTION
Divider was set to same color as background, now it uses the color from the parent theme.

![1584378664320](https://user-images.githubusercontent.com/40862101/76789162-f16e2580-67c4-11ea-8941-40605663960a.jpg)
