### PR TITLE
Another try fixing the Yandex image search URL

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/ImageSearch.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/ImageSearch.java
@@ -109,7 +109,7 @@ public abstract class ImageSearch {
             }
 
             public String getUrl(String imageUrl) {
-                return "https://www.yandex.com/images/search?rpt=imageview&url=" + imageUrl;
+                return "https://yandex.com/images/search?rpt=imageview&url=" + imageUrl;
             }
         });
     }


### PR DESCRIPTION
Sorry, it seems I did not test this thoroughly enough, the URL in the previous PR #824 worked fine on the emulator so I thought it was fixed but it gives an 400 Bad Request error on my actual Android device. This one works, it's now [the same as on 4chan-X.](https://github.com/ccd0/4chan-x/blob/4c41f0057207819b147cab9dc6f5210a16c6ad8a/src/config/Config.coffee#L782)