### PR TITLE
Menu for multiple filter options in post menu

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -896,10 +896,10 @@ public class ThreadPresenter
                 menu.add(new FloatingMenuItem(POST_OPTION_HIGHLIGHT_TRIPCODE, R.string.post_highlight_tripcode));
                 menu.add(new FloatingMenuItem(POST_OPTION_FILTER_TRIPCODE, R.string.post_filter_tripcode));
             }
+        }
 
-            if (loadable.site.siteFeature(Site.SiteFeature.IMAGE_FILE_HASH) && !post.images.isEmpty()) {
-                menu.add(new FloatingMenuItem(POST_OPTION_FILTER_IMAGE_HASH, R.string.post_filter_image_hash));
-            }
+        if (loadable.site.siteFeature(Site.SiteFeature.IMAGE_FILE_HASH) && !post.images.isEmpty()) {
+            menu.add(new FloatingMenuItem(POST_OPTION_FILTER_IMAGE_HASH, R.string.post_filter_image_hash));
         }
 
         if (loadable.site.siteFeature(Site.SiteFeature.POST_DELETE) && databaseManager.getDatabaseSavedReplyManager()

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -924,7 +924,8 @@ public class ThreadPresenter
         if (!TextUtils.isEmpty(post.tripcode)) {
             filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_TRIPCODE, R.string.filter_tripcode));
         }
-        if (loadable.board.countryFlags || loadable.boardCode.equals("pol")) {
+        if (loadable.board.countryFlags || (loadable.board.site.name().equals("4chan") &&
+                loadable.board.code.equals("pol"))) {
             filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_COUNTRY_CODE, R.string.filter_country_code));
         }
         if (!post.images.isEmpty()) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -77,6 +77,7 @@ import com.github.adamantcheese.chan.utils.PostUtils;
 import com.github.k1rakishou.fsaf.FileManager;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -116,11 +117,18 @@ public class ThreadPresenter
     private static final int POST_OPTION_HIGHLIGHT_TRIPCODE = 11;
     private static final int POST_OPTION_HIDE = 12;
     private static final int POST_OPTION_OPEN_BROWSER = 13;
-    private static final int POST_OPTION_FILTER_TRIPCODE = 14;
-    private static final int POST_OPTION_FILTER_IMAGE_HASH = 15;
-    private static final int POST_OPTION_EXTRA = 16;
-    private static final int POST_OPTION_REMOVE = 17;
-    private static final int POST_OPTION_MOCK_REPLY = 18;
+    private static final int POST_OPTION_FILTER = 14;
+    private static final int POST_OPTION_FILTER_TRIPCODE = 15;
+    private static final int POST_OPTION_FILTER_IMAGE_HASH = 16;
+    private static final int POST_OPTION_FILTER_SUBJECT = 17;
+    private static final int POST_OPTION_FILTER_COMMENT = 18;
+    private static final int POST_OPTION_FILTER_NAME = 19;
+    private static final int POST_OPTION_FILTER_ID = 20;
+    private static final int POST_OPTION_FILTER_FILENAME = 21;
+    private static final int POST_OPTION_FILTER_COUNTRY_CODE = 22;
+    private static final int POST_OPTION_EXTRA = 23;
+    private static final int POST_OPTION_REMOVE = 24;
+    private static final int POST_OPTION_MOCK_REPLY = 25;
 
     private final WatchManager watchManager;
     private final DatabaseManager databaseManager;
@@ -867,7 +875,11 @@ public class ThreadPresenter
     }
 
     @Override
-    public Object onPopulatePostOptions(Post post, List<FloatingMenuItem> menu, List<FloatingMenuItem> extraMenu) {
+    public List<Object> onPopulatePostOptions(
+            Post post, List<FloatingMenuItem> menu, List<List<FloatingMenuItem>> extraMenus) {
+        List<FloatingMenuItem> extraMenu = extraMenus.get(0);
+        List<FloatingMenuItem> filterMenu = extraMenus.get(1);
+
         if (!isBound()) return null;
         if (loadable.isCatalogMode()) {
             menu.add(new FloatingMenuItem(POST_OPTION_PIN, R.string.action_pin));
@@ -894,13 +906,35 @@ public class ThreadPresenter
 
             if (!TextUtils.isEmpty(post.tripcode)) {
                 menu.add(new FloatingMenuItem(POST_OPTION_HIGHLIGHT_TRIPCODE, R.string.post_highlight_tripcode));
-                menu.add(new FloatingMenuItem(POST_OPTION_FILTER_TRIPCODE, R.string.post_filter_tripcode));
             }
         }
 
-        if (loadable.site.siteFeature(Site.SiteFeature.IMAGE_FILE_HASH) && !post.images.isEmpty()) {
-            menu.add(new FloatingMenuItem(POST_OPTION_FILTER_IMAGE_HASH, R.string.post_filter_image_hash));
+        menu.add(new FloatingMenuItem(POST_OPTION_FILTER, R.string.post_filter));
+        if (post.isOP && !TextUtils.isEmpty(post.subject)) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_SUBJECT, R.string.filter_subject));
         }
+        if (!TextUtils.isEmpty(post.comment)) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_COMMENT, R.string.filter_comment));
+        }
+        if (!TextUtils.isEmpty(post.name) && !TextUtils.equals(post.name, "Anonymous")) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_NAME, R.string.filter_name));
+        }
+        if (!TextUtils.isEmpty(post.id)) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_ID, R.string.filter_id));
+        }
+        if (!TextUtils.isEmpty(post.tripcode)) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_TRIPCODE, R.string.filter_tripcode));
+        }
+        if (loadable.board.countryFlags || loadable.boardCode.equals("pol")) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_COUNTRY_CODE, R.string.filter_country_code));
+        }
+        if (!post.images.isEmpty()) {
+            filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_FILENAME, R.string.filter_filename));
+            if (loadable.site.siteFeature(Site.SiteFeature.IMAGE_FILE_HASH)) {
+                filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_IMAGE_HASH, R.string.filter_image_hash));
+            }
+        }
+
 
         if (loadable.site.siteFeature(Site.SiteFeature.POST_DELETE) && databaseManager.getDatabaseSavedReplyManager()
                 .isSaved(post.board, post.no) && !loadable.isLocal()) {
@@ -930,8 +964,7 @@ public class ThreadPresenter
                 extraMenu.add(new FloatingMenuItem(POST_OPTION_MOCK_REPLY, R.string.mock_reply));
             }
         }
-
-        return POST_OPTION_EXTRA;
+        return Arrays.asList(POST_OPTION_EXTRA, POST_OPTION_FILTER);
     }
 
     public void onPostOptionClicked(Post post, Object id, boolean inPopup) {
@@ -966,6 +999,24 @@ public class ThreadPresenter
                 break;
             case POST_OPTION_HIGHLIGHT_TRIPCODE:
                 threadPresenterCallback.highlightPostTripcode(post.tripcode);
+                break;
+            case POST_OPTION_FILTER_SUBJECT:
+                threadPresenterCallback.filterPostSubject(post.subject);
+                break;
+            case POST_OPTION_FILTER_COMMENT:
+                threadPresenterCallback.filterPostComment(post.comment);
+                break;
+            case POST_OPTION_FILTER_NAME:
+                threadPresenterCallback.filterPostName(post.name);
+                break;
+            case POST_OPTION_FILTER_FILENAME:
+                threadPresenterCallback.filterPostFilename(post);
+                break;
+            case POST_OPTION_FILTER_COUNTRY_CODE:
+                threadPresenterCallback.filterPostCountryCode(post);
+                break;
+            case POST_OPTION_FILTER_ID:
+                threadPresenterCallback.filterPostID(post.id);
                 break;
             case POST_OPTION_FILTER_TRIPCODE:
                 threadPresenterCallback.filterPostTripcode(post.tripcode);
@@ -1442,6 +1493,18 @@ public class ThreadPresenter
         void highlightPostId(String id);
 
         void highlightPostTripcode(String tripcode);
+
+        void filterPostSubject(String subject);
+
+        void filterPostName(String name);
+
+        void filterPostComment(CharSequence comment);
+
+        void filterPostID(String ID);
+
+        void filterPostCountryCode(Post post);
+
+        void filterPostFilename(Post post);
 
         void filterPostTripcode(String tripcode);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -909,7 +909,6 @@ public class ThreadPresenter
             }
         }
 
-        menu.add(new FloatingMenuItem(POST_OPTION_FILTER, R.string.post_filter));
         if (post.isOP && !TextUtils.isEmpty(post.subject)) {
             filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_SUBJECT, R.string.filter_subject));
         }
@@ -933,6 +932,17 @@ public class ThreadPresenter
             if (loadable.site.siteFeature(Site.SiteFeature.IMAGE_FILE_HASH)) {
                 filterMenu.add(new FloatingMenuItem(POST_OPTION_FILTER_IMAGE_HASH, R.string.filter_image_hash));
             }
+        }
+
+        //if the filter menu only has a single option we place just that option in the root menu
+        //in some cases a post will have nothing in it to filter (for example a post with no text and an image
+        //that is removed by a filter), in such cases there is no filter menu option.
+        if (filterMenu.size() > 1) {
+            menu.add(new FloatingMenuItem(POST_OPTION_FILTER, R.string.post_filter));
+        } else if (filterMenu.size() == 1) {
+            FloatingMenuItem menuItem = filterMenu.remove(0);
+            menuItem.setText("Filter " + menuItem.getText().toLowerCase());
+            menu.add(menuItem);
         }
 
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/CardPostCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/CardPostCell.java
@@ -100,23 +100,28 @@ public class CardPostCell
 
         options.setOnClickListener(v -> {
             List<FloatingMenuItem> items = new ArrayList<>();
-            List<FloatingMenuItem> extraItems = new ArrayList<>();
-            Object extraOption = callback.onPopulatePostOptions(post, items, extraItems);
-            showOptions(v, items, extraItems, extraOption);
+            List<List<FloatingMenuItem>> extraItems = new ArrayList<>();
+            extraItems.add(new ArrayList<>());
+            extraItems.add(new ArrayList<>());
+            List<Object> extraOptions = callback.onPopulatePostOptions(post, items, extraItems);
+            showOptions(v, items, extraItems, extraOptions);
         });
     }
 
     private void showOptions(
-            View anchor, List<FloatingMenuItem> items, List<FloatingMenuItem> extraItems, Object extraOption
+            View anchor, List<FloatingMenuItem> items, List<List<FloatingMenuItem>> extraItems, List<Object> extraOptions
     ) {
         FloatingMenu menu = new FloatingMenu(getContext(), anchor, items);
         menu.setCallback(new FloatingMenu.FloatingMenuCallback() {
             @Override
             public void onFloatingMenuItemClicked(FloatingMenu menu, FloatingMenuItem item) {
-                if (item.getId() == extraOption) {
-                    showOptions(anchor, extraItems, null, null);
+                if (extraItems != null && extraOptions != null) {
+                    if (item.getId() == extraOptions.get(0)) {
+                        showOptions(anchor, extraItems.get(0), null, null);
+                    } else if (item.getId() == extraOptions.get(1)) {
+                        showOptions(anchor, extraItems.get(1), null, null);
+                    }
                 }
-
                 callback.onPostOptionClicked(post, item.getId(), false);
             }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCell.java
@@ -216,9 +216,11 @@ public class PostCell
 
         options.setOnClickListener(v -> {
             List<FloatingMenuItem> items = new ArrayList<>();
-            List<FloatingMenuItem> extraItems = new ArrayList<>();
-            Object extraOption = callback.onPopulatePostOptions(post, items, extraItems);
-            showOptions(v, items, extraItems, extraOption);
+            List<List<FloatingMenuItem>> extraItems = new ArrayList<>();
+            extraItems.add(new ArrayList<>());
+            extraItems.add(new ArrayList<>());
+            List<Object> extraOptions = callback.onPopulatePostOptions(post, items, extraItems);
+            showOptions(v, items, extraItems, extraOptions);
         });
 
         setOnClickListener(v -> {
@@ -233,7 +235,7 @@ public class PostCell
     }
 
     private void showOptions(
-            View anchor, List<FloatingMenuItem> items, List<FloatingMenuItem> extraItems, Object extraOption
+            View anchor, List<FloatingMenuItem> items, List<List<FloatingMenuItem>> extraItems, List<Object> extraOptions
     ) {
         if (ThemeHelper.getTheme().isLightTheme) {
             options.setImageResource(R.drawable.ic_overflow_black);
@@ -243,10 +245,13 @@ public class PostCell
         menu.setCallback(new FloatingMenu.FloatingMenuCallback() {
             @Override
             public void onFloatingMenuItemClicked(FloatingMenu menu, FloatingMenuItem item) {
-                if (item.getId() == extraOption) {
-                    showOptions(anchor, extraItems, null, null);
+                if (extraItems != null && extraOptions != null) {
+                    if (item.getId() == extraOptions.get(0)) {
+                        showOptions(anchor, extraItems.get(0), null, null);
+                    } else if (item.getId() == extraOptions.get(1)) {
+                        showOptions(anchor, extraItems.get(1), null, null);
+                    }
                 }
-
                 callback.onPostOptionClicked(post, item.getId(), inPopup);
             }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCellInterface.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCellInterface.java
@@ -58,7 +58,8 @@ public interface PostCellInterface {
 
         void onShowPostReplies(Post post);
 
-        Object onPopulatePostOptions(Post post, List<FloatingMenuItem> menu, List<FloatingMenuItem> extraMenu);
+        List<Object> onPopulatePostOptions(
+                Post post, List<FloatingMenuItem> menu, List<List<FloatingMenuItem>> extraMenus);
 
         void onPostOptionClicked(Post post, Object id, boolean inPopup);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostStubCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostStubCell.java
@@ -90,23 +90,28 @@ public class PostStubCell
 
         options.setOnClickListener(v -> {
             List<FloatingMenuItem> items = new ArrayList<>();
-            List<FloatingMenuItem> extraItems = new ArrayList<>();
-            Object extraOption = callback.onPopulatePostOptions(post, items, extraItems);
-            showOptions(v, items, extraItems, extraOption);
+            List<List<FloatingMenuItem>> extraItems = new ArrayList<>();
+            extraItems.add(new ArrayList<>());
+            extraItems.add(new ArrayList<>());
+            List<Object> extraOptions = callback.onPopulatePostOptions(post, items, extraItems);
+            showOptions(v, items, extraItems, extraOptions);
         });
     }
 
     private void showOptions(
-            View anchor, List<FloatingMenuItem> items, List<FloatingMenuItem> extraItems, Object extraOption
+            View anchor, List<FloatingMenuItem> items, List<List<FloatingMenuItem>> extraItems, List<Object> extraOptions
     ) {
         FloatingMenu menu = new FloatingMenu(getContext(), anchor, items);
         menu.setCallback(new FloatingMenu.FloatingMenuCallback() {
             @Override
             public void onFloatingMenuItemClicked(FloatingMenu menu, FloatingMenuItem item) {
-                if (item.getId() == extraOption) {
-                    showOptions(anchor, extraItems, null, null);
+                if (extraItems != null && extraOptions != null) {
+                    if (item.getId() == extraOptions.get(0)) {
+                        showOptions(anchor, extraItems.get(0), null, null);
+                    } else if (item.getId() == extraOptions.get(1)) {
+                        showOptions(anchor, extraItems.get(1), null, null);
+                    }
                 }
-
                 callback.onPostOptionClicked(post, item.getId(), false);
             }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/ThemeSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/ThemeSettingsController.java
@@ -118,9 +118,9 @@ public class ThemeSettingsController
         }
 
         @Override
-        public Object onPopulatePostOptions(Post post, List<FloatingMenuItem> menu, List<FloatingMenuItem> extraMenu) {
+        public List<Object> onPopulatePostOptions(Post post, List<FloatingMenuItem> menu, List<List<FloatingMenuItem>> extraMenus) {
             menu.add(new FloatingMenuItem(1, "Option"));
-            return 0;
+            return null;
         }
 
         @Override

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
@@ -43,6 +43,7 @@ import com.github.adamantcheese.chan.core.database.DatabaseManager;
 import com.github.adamantcheese.chan.core.manager.FilterType;
 import com.github.adamantcheese.chan.core.model.ChanThread;
 import com.github.adamantcheese.chan.core.model.Post;
+import com.github.adamantcheese.chan.core.model.PostHttpIcon;
 import com.github.adamantcheese.chan.core.model.PostImage;
 import com.github.adamantcheese.chan.core.model.PostLinkable;
 import com.github.adamantcheese.chan.core.model.orm.Loadable;
@@ -441,6 +442,46 @@ public class ThreadLayout
     @Override
     public void highlightPostTripcode(String tripcode) {
         threadListLayout.highlightPostTripcode(tripcode);
+    }
+
+    @Override
+    public void filterPostSubject(String subject) {
+        callback.openFilterForType(FilterType.SUBJECT, subject);
+    }
+
+    @Override
+    public void filterPostName(String name) {
+        callback.openFilterForType(FilterType.NAME, name);
+    }
+
+    @Override
+    public void filterPostID(String ID) {
+        callback.openFilterForType(FilterType.ID, ID);
+    }
+
+    @Override
+    public void filterPostComment(CharSequence comment) {
+        callback.openFilterForType(FilterType.COMMENT, comment.toString());
+    }
+
+    @Override
+    public void filterPostCountryCode(Post post) {
+        String countryCode = "";
+        if (post.httpIcons != null && !post.httpIcons.isEmpty()) {
+            for (PostHttpIcon icon : post.httpIcons) {
+                if (icon.url.toString().contains("troll") || icon.url.toString().contains("country")) {
+                    countryCode = icon.name.substring(icon.name.indexOf('/') + 1);
+                    break;
+                }
+            }
+        }
+        callback.openFilterForType(FilterType.COUNTRY_CODE, countryCode);
+    }
+
+    @Override
+    public void filterPostFilename(Post post) {
+        if (post.images.isEmpty()) return;
+        callback.openFilterForType(FilterType.FILENAME, post.image().filename);
     }
 
     @Override

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
@@ -455,8 +455,8 @@ public class ThreadLayout
     }
 
     @Override
-    public void filterPostID(String ID) {
-        callback.openFilterForType(FilterType.ID, ID);
+    public void filterPostID(String id) {
+        callback.openFilterForType(FilterType.ID, id);
     }
 
     @Override

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -296,8 +296,6 @@ Note that for country code filtering, troll country codes should be prepended wi
 
     <string name="post_highlight_id">Highlight ID</string>
     <string name="post_highlight_tripcode">Highlight tripcode</string>
-    <string name="post_filter_tripcode">Filter tripcode</string>
-    <string name="post_filter_image_hash">Filter image hash</string>
     <string name="post_text_copied">Text copied to clipboard</string>
     <string name="post_quote">Quote</string>
     <string name="post_quote_text">Quote text</string>
@@ -314,6 +312,7 @@ Note that for country code filtering, troll country codes should be prepended wi
     <string name="thread_hidden">Thread hidden</string>
     <string name="thread_removed">Thread removed</string>
     <string name="post_delete">Delete</string>
+    <string name="post_filter">Filter…</string>
     <string name="post_more">More…</string>
     <string name="reply_name">Name</string>
     <string name="reply_options">Options</string>


### PR DESCRIPTION
Adds a filter submenu into the reply menu that can contain multiple filter options. Each filter option is shown only when it is applicable to the post.

Few things to mention:
* For some reason the boolean value `loadable.board.countryFlags` returns false on /pol/ so it needed its own special case.
* Filter comment option currently copies the whole post text, including reply links (ie. >>4275975). I was considering removing them with regex but maybe there's a better way to get the post text without reply links? Or perhaps just keep it as is?