### PR TITLE
Add a submenu for multiple filter options in post menu

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/CardPostCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/CardPostCell.java
@@ -117,7 +117,7 @@ public class CardPostCell
                     showOptions(anchor, extraItems, null, null);
                 }
 
-                callback.onPostOptionClicked(post, item.getId(), false);
+                callback.onPostOptionClicked(anchor, post, item.getId(), false);
             }
 
             @Override

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCell.java
@@ -247,7 +247,7 @@ public class PostCell
                     showOptions(anchor, extraItems, null, null);
                 }
 
-                callback.onPostOptionClicked(post, item.getId(), inPopup);
+                callback.onPostOptionClicked(anchor, post, item.getId(), inPopup);
             }
 
             @Override

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCellInterface.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostCellInterface.java
@@ -16,6 +16,8 @@
  */
 package com.github.adamantcheese.chan.ui.cell;
 
+import android.view.View;
+
 import com.github.adamantcheese.chan.core.model.Post;
 import com.github.adamantcheese.chan.core.model.PostImage;
 import com.github.adamantcheese.chan.core.model.PostLinkable;
@@ -60,7 +62,7 @@ public interface PostCellInterface {
 
         Object onPopulatePostOptions(Post post, List<FloatingMenuItem> menu, List<FloatingMenuItem> extraMenu);
 
-        void onPostOptionClicked(Post post, Object id, boolean inPopup);
+        void onPostOptionClicked(View anchor, Post post, Object id, boolean inPopup);
 
         void onPostLinkableClicked(Post post, PostLinkable linkable);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostStubCell.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/cell/PostStubCell.java
@@ -107,7 +107,7 @@ public class PostStubCell
                     showOptions(anchor, extraItems, null, null);
                 }
 
-                callback.onPostOptionClicked(post, item.getId(), false);
+                callback.onPostOptionClicked(anchor, post, item.getId(), false);
             }
 
             @Override

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/ThemeSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/ThemeSettingsController.java
@@ -124,7 +124,7 @@ public class ThemeSettingsController
         }
 
         @Override
-        public void onPostOptionClicked(Post post, Object id, boolean inPopup) {
+        public void onPostOptionClicked(View anchor, Post post, Object id, boolean inPopup) {
         }
 
         @Override

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ThreadLayout.java
@@ -43,6 +43,7 @@ import com.github.adamantcheese.chan.core.database.DatabaseManager;
 import com.github.adamantcheese.chan.core.manager.FilterType;
 import com.github.adamantcheese.chan.core.model.ChanThread;
 import com.github.adamantcheese.chan.core.model.Post;
+import com.github.adamantcheese.chan.core.model.PostHttpIcon;
 import com.github.adamantcheese.chan.core.model.PostImage;
 import com.github.adamantcheese.chan.core.model.PostLinkable;
 import com.github.adamantcheese.chan.core.model.orm.Loadable;
@@ -441,6 +442,46 @@ public class ThreadLayout
     @Override
     public void highlightPostTripcode(String tripcode) {
         threadListLayout.highlightPostTripcode(tripcode);
+    }
+
+    @Override
+    public void filterPostSubject(String subject) {
+        callback.openFilterForType(FilterType.SUBJECT, subject);
+    }
+
+    @Override
+    public void filterPostName(String name) {
+        callback.openFilterForType(FilterType.NAME, name);
+    }
+
+    @Override
+    public void filterPostID(String id) {
+        callback.openFilterForType(FilterType.ID, id);
+    }
+
+    @Override
+    public void filterPostComment(CharSequence comment) {
+        callback.openFilterForType(FilterType.COMMENT, comment.toString());
+    }
+
+    @Override
+    public void filterPostCountryCode(Post post) {
+        String countryCode = "";
+        if (post.httpIcons != null && !post.httpIcons.isEmpty()) {
+            for (PostHttpIcon icon : post.httpIcons) {
+                if (icon.url.toString().contains("troll") || icon.url.toString().contains("country")) {
+                    countryCode = icon.name.substring(icon.name.indexOf('/') + 1);
+                    break;
+                }
+            }
+        }
+        callback.openFilterForType(FilterType.COUNTRY_CODE, countryCode);
+    }
+
+    @Override
+    public void filterPostFilename(Post post) {
+        if (post.images.isEmpty()) return;
+        callback.openFilterForType(FilterType.FILENAME, post.image().filename);
     }
 
     @Override

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -296,8 +296,6 @@ Note that for country code filtering, troll country codes should be prepended wi
 
     <string name="post_highlight_id">Highlight ID</string>
     <string name="post_highlight_tripcode">Highlight tripcode</string>
-    <string name="post_filter_tripcode">Filter tripcode</string>
-    <string name="post_filter_image_hash">Filter image hash</string>
     <string name="post_text_copied">Text copied to clipboard</string>
     <string name="post_quote">Quote</string>
     <string name="post_quote_text">Quote text</string>
@@ -314,6 +312,7 @@ Note that for country code filtering, troll country codes should be prepended wi
     <string name="thread_hidden">Thread hidden</string>
     <string name="thread_removed">Thread removed</string>
     <string name="post_delete">Delete</string>
+    <string name="post_filter">Filter…</string>
     <string name="post_more">More…</string>
     <string name="reply_name">Name</string>
     <string name="reply_options">Options</string>


### PR DESCRIPTION
Another try at this. Populating the the filter menu still happens when the post menu is populated because we need to know whether we'll be displaying a singular filter option or a menu of filter options.