### PR TITLE
More descriptive filter details

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/FiltersController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/FiltersController.java
@@ -43,11 +43,9 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -55,7 +53,6 @@ import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static com.github.adamantcheese.chan.Chan.inject;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getAttrColor;
-import static com.github.adamantcheese.chan.utils.AndroidUtils.getQuantityString;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getString;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.postToEventBus;
 import static com.github.adamantcheese.chan.utils.LayoutUtils.inflate;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/FiltersController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/FiltersController.java
@@ -43,9 +43,11 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -271,20 +273,28 @@ public class FiltersController
             holder.subtext.setTextColor(getAttrColor(context,
                     filter.enabled ? android.R.attr.textColorSecondary : android.R.attr.textColorHint
             ));
-            int types = FilterType.forFlags(filter.type).size();
-            String subText = getQuantityString(R.plurals.type, types, types);
 
-            subText += " \u2013 ";
-            if (filter.allBoards) {
-                subText += getString(R.string.filter_summary_all_boards);
+            StringBuilder subText = new StringBuilder();
+            int types = FilterType.forFlags(filter.type).size();
+            if (types == 1) {
+                subText.append(FilterType.filterTypeName(FilterType.forFlags(filter.type).get(0)));
             } else {
-                int size = filterEngine.getFilterBoardCount(filter);
-                subText += getQuantityString(R.plurals.board, size, size);
+                subText.append(String.format(Locale.ENGLISH, "%d types", types));
             }
 
-            subText += " \u2013 " + FilterAction.actionName(FilterAction.forId(filter.action));
+            subText.append(" \u2013 ");
+            if (filter.allBoards) {
+                subText.append(getString(R.string.filter_summary_all_boards));
+            } else if (filterEngine.getFilterBoardCount(filter) == 1) {
+                subText.append(String.format("/%s/", filter.boardCodesNoId()[0]));
+            } else {
+                int size = filterEngine.getFilterBoardCount(filter);
+                subText.append(String.format(Locale.ENGLISH, "%d boards", size));
+            }
 
-            holder.subtext.setText(subText);
+            subText.append(" \u2013 ").append(FilterAction.actionName(FilterAction.forId(filter.action)));
+
+            holder.subtext.setText(subText.toString());
         }
 
         @Override

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -31,10 +31,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item quantity="one">%d board</item>
         <item quantity="other">%d boards</item>
     </plurals>
-    <plurals name="type">
-        <item quantity="one">%d type</item>
-        <item quantity="other">%d types</item>
-    </plurals>
     <plurals name="bookmark">
         <item quantity="one">%d bookmark</item>
         <item quantity="other">%d bookmarks</item>


### PR DESCRIPTION
If a filter has only one board or filter type selected, the filter details will now specify which board/filter type is selected rather than just displaying "1 board" or "1 type".

![Screenshot_20200612-204225352_2](https://user-images.githubusercontent.com/40862101/84532116-59fa6f00-acee-11ea-8f89-f34379fdcf9a.jpg)
