### PR TITLE
Change default accent colors for dark themes

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/Theme.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/Theme.java
@@ -121,6 +121,7 @@ public class Theme {
         LIGHT_BLUE(R.style.PrimaryLightBlue, R.style.AccentLightBlue),
         CYAN(R.style.PrimaryCyan, R.style.AccentCyan),
         TEAL(R.style.PrimaryTeal, R.style.AccentTeal),
+        DARK_TEAL(R.style.PrimaryDarkTeal, R.style.AccentDarkTeal),
         GREEN(R.style.PrimaryGreen, R.style.AccentGreen),
         LIGHT_GREEN(R.style.PrimaryLightGreen, R.style.AccentLightGreen),
         LIME(R.style.PrimaryLime, R.style.AccentLime),

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/ThemeHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/ThemeHelper.java
@@ -35,10 +35,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.github.adamantcheese.chan.Chan.instance;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.AMBER;
 import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.BLACK;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.BLUE_GREY;
 import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.BROWN;
 import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.DARK;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.DARK_TEAL;
 import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.GREEN;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.GREY;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.INDIGO;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.LIGHT_BLUE;
+import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.LIGHT_BLUE_GREY;
 import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.ORANGE;
 import static com.github.adamantcheese.chan.ui.theme.Theme.MaterialColorStyle.RED;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getAppContext;
@@ -63,7 +70,7 @@ public class ThemeHelper {
     private Theme themeNight;
     public static boolean isNightTheme = false;
     public static Theme defaultDayTheme = new Theme("Yotsuba B", R.style.Chan_Theme_YotsubaB, RED, RED);
-    public static Theme defaultNightTheme = new Theme("Dark", R.style.Chan_Theme_Dark, DARK, BLACK);
+    public static Theme defaultNightTheme = new Theme("Dark", R.style.Chan_Theme_Dark, DARK, DARK_TEAL);
 
     private static final Typeface TALLEYRAND =
             Typeface.createFromAsset(getAppContext().getAssets(), "font/Talleyrand.ttf");
@@ -73,16 +80,16 @@ public class ThemeHelper {
     public ThemeHelper() {
         themes.add(new Theme("Light", R.style.Chan_Theme_Light, GREEN, GREEN));
         themes.add(defaultNightTheme);
-        themes.add(new Theme("Black", R.style.Chan_Theme_Black, BLACK, DARK));
-        themes.add(new Theme("Tomorrow", R.style.Chan_Theme_Tomorrow, DARK, BLACK));
-        themes.add(new Theme("Tomorrow Black", R.style.Chan_Theme_TomorrowBlack, BLACK, DARK));
+        themes.add(new Theme("Black", R.style.Chan_Theme_Black, BLACK, INDIGO));
+        themes.add(new Theme("Tomorrow", R.style.Chan_Theme_Tomorrow, DARK, LIGHT_BLUE_GREY));
+        themes.add(new Theme("Tomorrow Black", R.style.Chan_Theme_TomorrowBlack, BLACK, LIGHT_BLUE_GREY));
         themes.add(new Theme("Yotsuba", R.style.Chan_Theme_Yotsuba, RED, RED));
         themes.add(defaultDayTheme);
         themes.add(new Theme("Photon", R.style.Chan_Theme_Photon, ORANGE, ORANGE));
-        themes.add(new Theme("Insomnia", R.style.Chan_Theme_Insomnia, DARK, BLACK));
-        themes.add(new Theme("Gruvbox", R.style.Chan_Theme_Gruvbox, DARK, BLACK));
-        themes.add(new Theme("Gruvbox Black", R.style.Chan_Theme_GruvboxBlack, BLACK, DARK));
-        themes.add(new Theme("Neon", R.style.Chan_Theme_Neon, DARK, BLACK));
+        themes.add(new Theme("Insomnia", R.style.Chan_Theme_Insomnia, DARK, BLUE_GREY));
+        themes.add(new Theme("Gruvbox", R.style.Chan_Theme_Gruvbox, DARK, AMBER));
+        themes.add(new Theme("Gruvbox Black", R.style.Chan_Theme_GruvboxBlack, BLACK, AMBER));
+        themes.add(new Theme("Neon", R.style.Chan_Theme_Neon, DARK, LIGHT_BLUE));
         themes.add(new Theme("Solarized Dark", R.style.Chan_Theme_SolarizedDark, ORANGE, ORANGE));
         Theme holo = new Theme("Holo", R.style.Chan_Theme_Holo, BROWN, RED, TALLEYRAND, OPTI_CUBA_LIBRE_TWO);
         holo.altFontIsMain = true;

--- a/Kuroba/app/src/main/res/layout/layout_select.xml
+++ b/Kuroba/app/src/main/res/layout/layout_select.xml
@@ -39,6 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             android:id="@+id/select_all"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
+            style="@style/Widget.AppCompat.Button.Borderless"
             tools:text="@string/select_all" />
 
     </LinearLayout>

--- a/Kuroba/app/src/main/res/values/styles.xml
+++ b/Kuroba/app/src/main/res/values/styles.xml
@@ -403,6 +403,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="colorPrimaryDark">@color/md_teal_700</item>
     </style>
 
+    <style name="PrimaryDarkTeal">
+        <item name="colorPrimary">@color/md_teal_700</item>
+        <item name="colorPrimaryDark">@color/md_teal_900</item>
+    </style>
+
     <style name="PrimaryGreen">
         <item name="colorPrimary">@color/md_green_500</item>
         <item name="colorPrimaryDark">@color/md_green_700</item>
@@ -505,6 +510,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <style name="AccentTeal">
         <item name="colorAccent">@color/md_teal_A700</item>
+    </style>
+
+    <style name="AccentDarkTeal">
+        <item name="colorAccent">@color/md_teal_500</item>
     </style>
 
     <style name="AccentGreen">


### PR DESCRIPTION
Dark themes had the accent set to dark/black by default which was causing a lot of visibility issues. It seems many people haven't figured out the accent color is changeable. This PR changes the default accent colors of dark themes to be brighter and more easily distinguishable from the background. I tried to pick each accent color so that it fits the theme it's set for.

Also includes a tiny change to the select layout, the 'SELECT ALL' button in the filter menu (under filter type and board) now matches the style of the button elsewhere in the app.

EDIT: if this gets merged would you consider reverting ba5a721 ? Since the loading bar following the accent color (which is a nice idea I think) wasn't really the issue per se but rather the accent color being set to dark/black on a dark theme.