### PR TITLE
Add back Gruvbox Light theme

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/ThemeHelper.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/ThemeHelper.java
@@ -92,7 +92,8 @@ public class ThemeHelper {
         themes.add(defaultDayTheme);
         themes.add(new Theme("Photon", R.style.Chan_Theme_Photon, ORANGE, ORANGE));
         themes.add(new Theme("Insomnia", R.style.Chan_Theme_Insomnia, DARK, BLUE_GREY));
-        themes.add(new Theme("Gruvbox", R.style.Chan_Theme_Gruvbox, DARK, TAN));
+        themes.add(new Theme("Gruvbox Light", R.style.Chan_Theme_GruvboxLight, TAN, TAN));
+        themes.add(new Theme("Gruvbox Dark", R.style.Chan_Theme_GruvboxDark, DARK, TAN));
         themes.add(new Theme("Gruvbox Black", R.style.Chan_Theme_GruvboxBlack, BLACK, TAN));
         themes.add(new Theme("Neon", R.style.Chan_Theme_Neon, DARK, LIGHT_BLUE));
         themes.add(new Theme("Solarized Dark", R.style.Chan_Theme_SolarizedDark, ORANGE, ORANGE));

--- a/Kuroba/app/src/main/res/values/styles.xml
+++ b/Kuroba/app/src/main/res/values/styles.xml
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="colorSurface">@color/white</item>
         <item name="textAppearanceBody2">@style/TextAppearance.MaterialComponents.Body2</item>
         <item name="android:alertDialogTheme">@style/AlertDialogStyle</item>
+        <item name="android:listPopupWindowStyle">@style/ListPopupWindowStyle</item>
 
         <item name="colorControlNormal">@color/textColorSecondary</item>
         <item name="themeDrawableColor">@color/md_grey_600</item>
@@ -58,6 +59,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="colorSurface">@color/white</item>
         <item name="textAppearanceBody2">@style/TextAppearance.MaterialComponents.Body2</item>
         <item name="android:alertDialogTheme">@style/AlertDialogStyle</item>
+        <item name="android:listPopupWindowStyle">@style/ListPopupWindowStyle</item>
 
         <item name="colorControlNormal">@color/textColorSecondary</item>
         <item name="themeDrawableColor">@color/white</item>
@@ -267,7 +269,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="android:textColorLink">#81a2be</item>
     </style>
 
-    <style name="Chan.Theme.Gruvbox" parent="Chan.Theme.Dark">
+    <style name="Chan.Theme.GruvboxLight" parent="Chan.Theme.BaseLight">
+        <item name="backcolor">#fbf1c7</item>
+        <item name="backcolor_secondary">#ebdbb2</item>
+
+        <item name="android:textColor">#3c3836</item>
+        <item name="android:textColorPrimary">#3c3836</item>
+        <item name="android:textColorSecondary">#504945</item>
+        <item name="android:textColorHint">#665c54</item>
+
+        <item name="highlight_color">#ebdbb2</item>
+        <item name="divider_color">#ebdbb2</item>
+
+        <item name="post_name_color">#427b58</item>
+        <item name="post_subject_color">#076678</item>
+        <item name="post_details_color">#7c6f64</item>
+        <item name="post_quote_color">#9d0006</item>
+        <item name="post_inline_quote_color">#79740e</item>
+        <item name="post_spoiler_color">#3c3836</item>
+        <item name="android:textColorLink">#076678</item>
+    </style>
+
+    <style name="Chan.Theme.GruvboxDark" parent="Chan.Theme.Dark">
         <item name="backcolor">@color/md_grey_875</item>
         <item name="backcolor_secondary">#3c3836</item>
 
@@ -288,7 +311,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="android:textColorLink">#458588</item>
     </style>
 
-    <style name="Chan.Theme.GruvboxBlack" parent="Chan.Theme.Gruvbox">
+    <style name="Chan.Theme.GruvboxBlack" parent="Chan.Theme.GruvboxDark">
         <item name="backcolor">@color/black</item>
 
         <item name="highlight_color">#1CFFFFFF</item>
@@ -630,6 +653,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <style name="AlertDialogStyle" parent="@style/ThemeOverlay.AppCompat.Dialog.Alert">
         <item name="android:background">?backcolor</item>
+    </style>
+
+    <style name="ListPopupWindowStyle" parent="Widget.AppCompat.ListPopupWindow">
+        <item name="android:popupBackground">?backcolor</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Brings back Gruvbox Light theme originally added to Clover in https://github.com/chandevel/Clover/pull/329 by @TheLastZombie and later removed in https://github.com/chandevel/Clover/pull/335, with small color tweaks by me.

I also created a style for the popup menus so that the menu background color gets set according to the background color of the theme.

![Screenshot_20200707-163026761](https://user-images.githubusercontent.com/40862101/86788996-7b414780-c06f-11ea-9e1e-7409d3cf3ed9.jpg)
