### PR TITLE
Add a submenu with multiple copy options to post menu

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ThreadPresenter.java
@@ -1306,12 +1306,54 @@ public class ThreadPresenter
         if (post.isOP && !TextUtils.isEmpty(post.subject)) {
             text.append("Subject: ").append(post.subject).append("\n");
         }
+
+        if (!TextUtils.isEmpty(post.name) && !TextUtils.equals(post.name, "Anonymous")) {
+            text.append("Name: ").append(post.name).append("\n");
+        }
+
+        if (!TextUtils.isEmpty(post.tripcode)) {
+            text.append("Tripcode: ").append(post.tripcode).append("\n");
+        }
+
+        if (!TextUtils.isEmpty(post.capcode)) {
+            text.append("Capcode: ").append(post.capcode).append("\n");
+        }
+
+        if (!TextUtils.isEmpty(post.id) && isBound() && chanLoader.getThread() != null) {
+            text.append("Id: ").append(post.id).append("\n");
+            int count = 0;
+            try {
+                for (Post p : chanLoader.getThread().getPosts()) {
+                    if (p.id.equals(post.id)) count++;
+                }
+            } catch (Exception ignored) {
+            }
+            text.append("Post count: ").append(count).append("\n");
+        }
+
+        if (post.httpIcons != null && !post.httpIcons.isEmpty()) {
+            for (PostHttpIcon icon : post.httpIcons) {
+                if (icon.url.toString().contains("troll")) {
+                    text.append("Troll Country: ").append(icon.name).append("\n");
+                } else if (icon.url.toString().contains("country")) {
+                    text.append("Country: ").append(icon.name).append("\n");
+                } else if (icon.url.toString().contains("minileaf")) {
+                    text.append("4chan Pass Year: ").append(icon.name).append("\n");
+                }
+            }
+        }
+
+        text.append("Posted: ").append(PostHelper.getLocalDate(post));
+
         for (PostImage image : post.images) {
-            text.append("Filename: ").append(image.filename).append(".").append(image.extension);
+            text.append("\n\nFilename: ")
+                    .append(image.filename)
+                    .append(".")
+                    .append(image.extension);
             if (image.isInlined) {
                 text.append("\nLinked file");
             } else {
-                text.append(" \nDimensions: ")
+                text.append("\nDimensions: ")
                         .append(image.imageWidth)
                         .append("x")
                         .append(image.imageHeight)
@@ -1322,43 +1364,8 @@ public class ThreadPresenter
             if (image.spoiler() && !image.isInlined) { //all linked files are spoilered, don't say that
                 text.append("\nSpoilered");
             }
-
-            text.append("\n");
         }
 
-        text.append("Posted: ").append(PostHelper.getLocalDate(post));
-
-        if (!TextUtils.isEmpty(post.id) && isBound() && chanLoader.getThread() != null) {
-            text.append("\nId: ").append(post.id);
-            int count = 0;
-            try {
-                for (Post p : chanLoader.getThread().getPosts()) {
-                    if (p.id.equals(post.id)) count++;
-                }
-            } catch (Exception ignored) {
-            }
-            text.append("\nCount: ").append(count);
-        }
-
-        if (!TextUtils.isEmpty(post.tripcode)) {
-            text.append("\nTripcode: ").append(post.tripcode);
-        }
-
-        if (post.httpIcons != null && !post.httpIcons.isEmpty()) {
-            for (PostHttpIcon icon : post.httpIcons) {
-                if (icon.url.toString().contains("troll")) {
-                    text.append("\nTroll Country: ").append(icon.name);
-                } else if (icon.url.toString().contains("country")) {
-                    text.append("\nCountry: ").append(icon.name);
-                } else if (icon.url.toString().contains("minileaf")) {
-                    text.append("\n4chan Pass Year: ").append(icon.name);
-                }
-            }
-        }
-
-        if (!TextUtils.isEmpty(post.capcode)) {
-            text.append("\nCapcode: ").append(post.capcode);
-        }
         AlertDialog.Builder alertDialogbuilder = new AlertDialog.Builder(context);
         AlertDialog dialog = alertDialogbuilder
                 .setMessage(text.toString())

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -309,14 +309,25 @@ Enabled filters have priority from top to bottom in your list. Filter precedence
 
     <string name="post_highlight_id">Highlight ID</string>
     <string name="post_highlight_tripcode">Highlight tripcode</string>
-    <string name="post_text_copied">Text copied to clipboard</string>
     <string name="post_quote">Quote</string>
     <string name="post_quote_text">Quote text</string>
-    <string name="post_info">Info</string>
-    <string name="post_info_title">Post info</string>
+    <string name="post_info">Post info</string>
     <string name="post_show_links">Show links</string>
     <string name="post_share">Share</string>
-    <string name="post_copy_text">Copy text</string>
+
+    <string name="post_copy_menu">Copy…</string>
+    <string name="post_copy_text">Post text</string>
+    <string name="post_copy_link">Post link</string>
+    <string name="post_copy_cross_board_link">Cross-board link</string>
+    <string name="post_copy_image_url">Image URL</string>
+    <string name="post_copy_post_url">Post URL</string>
+    <string name="post_copy_links">Links in post</string>
+
+    <string name="post_link_copied">Link copied to clipboard</string>
+    <string name="post_cross_board_link_copied">Cross-board link copied to clipboard</string>
+    <string name="post_url_copied">Post URL copied to clipboard</string>
+    <string name="post_text_copied">Text copied to clipboard</string>
+
     <string name="post_report">Report</string>
     <string name="post_hide">Hide</string>
     <string name="post_remove">Remove</string>

--- a/Kuroba/app/src/main/res/values/styles.xml
+++ b/Kuroba/app/src/main/res/values/styles.xml
@@ -660,7 +660,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </style>
 
     <style name="AlertDialogStyle" parent="@style/ThemeOverlay.AppCompat.Dialog.Alert">
-        <item name="android:background">?backcolor</item>
+        <item name="android:windowBackground">?backcolor</item>
     </style>
 
     <style name="ListPopupWindowStyle" parent="Widget.AppCompat.ListPopupWindow">


### PR DESCRIPTION
The "Copy text" option in post menu is replaced with a Copy submenu with the following options:

- Copy link (eg. >>6235023)
- Copy cross-board link (eg. >>>/g/6235023)
- Copy post text
- Copy post URL
- Copy image URL
- Copy links in post (opens the "Show links" dialog)
- Copy post info (opens the "Post info" dialog)

For the last option to make sense, the post info dialog was changed to have selectable text.

In action:

![ex1](https://user-images.githubusercontent.com/40862101/87885390-37125780-ca1e-11ea-834e-376974a6378a.gif)


Other, smaller changes:

1. Post info now displays the subject and name, allowing the user to copy them to the clipboard.
2. Swapped position of filter and copy option so copy appears under the main menu and filter under "more..."
2. "Show links" option is only shown if there is at least one linkable in the post.
3. Long-press on a link under "Show links" would trigger a normal click and a long click. The fix was to make [long click listener return true instead of false.](https://stackoverflow.com/questions/5428077/android-why-does-long-click-also-trigger-a-normal-click)
4. AlertDialog style was being applied to the context menu causing unwanted effects (see below), Fixed by changing [`android:background` to `android:windowBackground`.](https://stackoverflow.com/questions/62035073/weird-popup-menu-in-alertdialog-with-custom-background-style)

![Screenshot_1595190043](https://user-images.githubusercontent.com/40862101/87884495-3aeeab80-ca17-11ea-9cb2-bdb4df080b41.png)


