### PR TITLE
Separate folder setting for images and albums

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/settings/ChanSettings.java
@@ -278,8 +278,10 @@ public class ChanSettings {
     // Saving
     public static final SavedFilesBaseDirSetting saveLocation;
     public static final LocalThreadsBaseDirSetting localThreadLocation;
-    public static final BooleanSetting saveBoardFolder;
-    public static final BooleanSetting saveThreadFolder;
+    public static final BooleanSetting saveImageBoardFolder;
+    public static final BooleanSetting saveImageThreadFolder;
+    public static final BooleanSetting saveAlbumBoardFolder;
+    public static final BooleanSetting saveAlbumThreadFolder;
     public static final BooleanSetting saveServerFilename;
     public static final BooleanSetting incrementalThreadDownloadingEnabled;
 
@@ -444,8 +446,10 @@ public class ChanSettings {
             // Saving
             saveLocation = new SavedFilesBaseDirSetting(p);
             localThreadLocation = new LocalThreadsBaseDirSetting(p);
-            saveBoardFolder = new BooleanSetting(p, "preference_save_subboard", false);
-            saveThreadFolder = new BooleanSetting(p, "preference_save_subthread", false);
+            saveImageBoardFolder = new BooleanSetting(p, "preference_save_image_subboard", false);
+            saveImageThreadFolder = new BooleanSetting(p, "preference_save_image_subthread", false);
+            saveAlbumBoardFolder = new BooleanSetting(p, "preference_save_album_subboard", false);
+            saveAlbumThreadFolder = new BooleanSetting(p, "preference_save_album_subthread", false);
             saveServerFilename = new BooleanSetting(p, "preference_image_save_original", false);
             incrementalThreadDownloadingEnabled = new BooleanSetting(p, "incremental_thread_downloading", true);
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
@@ -112,7 +112,7 @@ public class AlbumDownloadController
                 showToast(context, R.string.album_download_none_checked);
             } else {
                 String siteNameSafe = StringUtils.dirNameRemoveBadCharacters(loadable.site.name());
-                String subFolder = ChanSettings.saveBoardFolder.get() ? (ChanSettings.saveThreadFolder.get()
+                String subFolder = ChanSettings.saveAlbumBoardFolder.get() ? (ChanSettings.saveAlbumThreadFolder.get()
                         ? appendAdditionalSubDirectories()
                         : siteNameSafe + File.separator + loadable.boardCode) : null;
                 String message = getString(

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ImageViewerController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/ImageViewerController.java
@@ -305,10 +305,10 @@ public class ImageViewerController
             shareLink(postImage.imageUrl.toString());
         } else {
             ImageSaveTask task = new ImageSaveTask(loadable, postImage, false, share);
-            if (ChanSettings.saveBoardFolder.get()) {
+            if (ChanSettings.saveImageBoardFolder.get()) {
                 String subFolderName;
 
-                if (ChanSettings.saveThreadFolder.get()) {
+                if (ChanSettings.saveImageThreadFolder.get()) {
                     subFolderName = appendAdditionalSubDirectories(postImage);
                 } else {
                     String siteNameSafe = StringUtils.dirNameRemoveBadCharacters(presenter.getLoadable().site.name());

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/MediaSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/MediaSettingsController.java
@@ -66,8 +66,10 @@ public class MediaSettingsController
         implements SaveLocationSetupDelegate.MediaControllerCallbacks,
                    ThreadsLocationSetupDelegate.MediaControllerCallbacks {
     // Special setting views
-    private BooleanSettingView boardFolderSetting;
-    private BooleanSettingView threadFolderSetting;
+    private BooleanSettingView imageBoardFolderSetting;
+    private BooleanSettingView imageThreadFolderSetting;
+    private BooleanSettingView albumBoardFolderSetting;
+    private BooleanSettingView albumThreadFolderSetting;
     private BooleanSettingView videoDefaultMutedSetting;
     private BooleanSettingView headsetDefaultMutedSetting;
     private LinkSettingView saveLocation;
@@ -119,7 +121,8 @@ public class MediaSettingsController
 
         onPreferenceChange(imageAutoLoadView);
 
-        threadFolderSetting.setEnabled(ChanSettings.saveBoardFolder.get());
+        imageThreadFolderSetting.setEnabled(ChanSettings.saveImageBoardFolder.get());
+        albumThreadFolderSetting.setEnabled(ChanSettings.saveAlbumBoardFolder.get());
         headsetDefaultMutedSetting.setEnabled(ChanSettings.videoDefaultMuted.get());
     }
 
@@ -137,8 +140,10 @@ public class MediaSettingsController
 
         if (item == imageAutoLoadView) {
             updateVideoLoadModes();
-        } else if (item == boardFolderSetting) {
-            updateThreadFolderSetting();
+        } else if (item == imageBoardFolderSetting) {
+            updateImageThreadFolderSetting();
+        } else if (item == albumBoardFolderSetting) {
+            updateAlbumThreadFolderSetting();
         } else if (item == videoDefaultMutedSetting) {
             updateHeadsetDefaultMutedSetting();
         } else if (item == incrementalThreadDownloadingSetting
@@ -176,16 +181,28 @@ public class MediaSettingsController
             setupLocalThreadLocationSetting(media);
 
             //Save modifications
-            boardFolderSetting = (BooleanSettingView) media.add(new BooleanSettingView(this,
-                    ChanSettings.saveBoardFolder,
-                    R.string.setting_save_board_folder,
-                    R.string.setting_save_board_folder_description
+            imageBoardFolderSetting = (BooleanSettingView) media.add(new BooleanSettingView(this,
+                    ChanSettings.saveImageBoardFolder,
+                    R.string.setting_save_image_board_folder,
+                    R.string.setting_save_image_board_folder_description
             ));
 
-            threadFolderSetting = (BooleanSettingView) media.add(new BooleanSettingView(this,
-                    ChanSettings.saveThreadFolder,
-                    R.string.setting_save_thread_folder,
-                    R.string.setting_save_thread_folder_description
+            imageThreadFolderSetting = (BooleanSettingView) media.add(new BooleanSettingView(this,
+                    ChanSettings.saveImageThreadFolder,
+                    R.string.setting_save_image_thread_folder,
+                    R.string.setting_save_image_thread_folder_description
+            ));
+
+            albumBoardFolderSetting = (BooleanSettingView) media.add(new BooleanSettingView(this,
+                    ChanSettings.saveAlbumBoardFolder,
+                    R.string.setting_save_album_board_folder,
+                    R.string.setting_save_album_board_folder_description
+            ));
+
+            albumThreadFolderSetting = (BooleanSettingView) media.add(new BooleanSettingView(this,
+                    ChanSettings.saveAlbumThreadFolder,
+                    R.string.setting_save_album_thread_folder,
+                    R.string.setting_save_album_thread_folder_description
             ));
 
             media.add(new BooleanSettingView(this,
@@ -424,15 +441,27 @@ public class MediaSettingsController
         }
     }
 
-    private void updateThreadFolderSetting() {
-        if (ChanSettings.saveBoardFolder.get()) {
-            threadFolderSetting.setEnabled(true);
+    private void updateImageThreadFolderSetting() {
+        if (ChanSettings.saveImageBoardFolder.get()) {
+            imageThreadFolderSetting.setEnabled(true);
         } else {
-            if (ChanSettings.saveThreadFolder.get()) {
-                threadFolderSetting.onClick(threadFolderSetting.view);
+            if (ChanSettings.saveImageThreadFolder.get()) {
+                imageThreadFolderSetting.onClick(imageThreadFolderSetting.view);
             }
-            threadFolderSetting.setEnabled(false);
-            ChanSettings.saveThreadFolder.set(false);
+            imageThreadFolderSetting.setEnabled(false);
+            ChanSettings.saveImageThreadFolder.set(false);
+        }
+    }
+
+    private void updateAlbumThreadFolderSetting() {
+        if (ChanSettings.saveAlbumBoardFolder.get()) {
+            albumThreadFolderSetting.setEnabled(true);
+        } else {
+            if (ChanSettings.saveAlbumThreadFolder.get()) {
+                albumThreadFolderSetting.onClick(albumThreadFolderSetting.view);
+            }
+            albumThreadFolderSetting.setEnabled(false);
+            ChanSettings.saveAlbumThreadFolder.set(false);
         }
     }
 

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -508,18 +508,22 @@ Enabled filters have priority from top to bottom in your list. Filter precedence
 
     <!-- Behavior proxy group -->
     <string name="setting_proxy_port">Proxy server port</string>
-    <string name="settings_screen_media">Media</string>
-    <string name="settings_group_saving">Media saving</string>
-    <string name="setting_save_board_folder">Save images in board folders</string>
+
 
 
     <!-- Media -->
-    <string name="setting_save_board_folder_description">Create a folder for each board when saving</string>
+    <string name="settings_screen_media">Media</string>
 
     <!-- Media general group -->
-    <string name="setting_save_thread_folder">Save images in thread folders</string>
-
-    <string name="setting_save_thread_folder_description">Create a folder for each thread when saving</string>
+    <string name="settings_group_saving">Media saving</string>
+    <string name="setting_save_image_board_folder">Save images in board folders</string>
+    <string name="setting_save_image_board_folder_description">Create a folder for each board when saving individual images</string>
+    <string name="setting_save_image_thread_folder">Save images in thread folders</string>
+    <string name="setting_save_image_thread_folder_description">Create a folder for each thread when saving individual images</string>
+    <string name="setting_save_album_board_folder">Save albums in board folders</string>
+    <string name="setting_save_album_board_folder_description">Create a folder for each board when saving image albums</string>
+    <string name="setting_save_album_thread_folder">Save albums in thread folders</string>
+    <string name="setting_save_album_thread_folder_description">Create a folder for each thread when saving image albums</string>
     <string name="setting_save_server_filename">Save server filename</string>
     <string name="setting_save_server_filename_description">Save the image with the filename the site assigned. If disabled, save the image with the filename the uploader assigned.</string>
     <string name="setting_video_default_muted">Start videos muted</string>


### PR DESCRIPTION
For #982. Adds separate folder settings for individual image downloads (through the image viewer) and album downloads (through thread image album).

![Screenshot_1594226289](https://user-images.githubusercontent.com/40862101/87885420-940e0d80-ca1e-11ea-8db1-ef6e945ce6b7.png)