### PR TITLE
Fix reply layout expansion arrow icon having wrong orientation with bottom input

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
@@ -247,8 +247,6 @@ public class ReplyLayout
         previewHolder.setOnLongClickListener(v -> presenter.filenameNewClicked(true));
 
         if (!isInEditMode()) {
-            more.setRotation(0f);
-        } else {
             more.setRotation(ChanSettings.moveInputToBottom.get() ? 180f : 0f);
         }
         more.setOnClickListener(this);


### PR DESCRIPTION
![Screenshot_1595410777](https://user-images.githubusercontent.com/40862101/88191451-204d4a00-cc44-11ea-8eaf-160305d5a492.png)
