### PR TITLE
fix italic text getting cut off in bookmarks list

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/DrawerAdapter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/DrawerAdapter.java
@@ -389,6 +389,8 @@ public class DrawerAdapter
             //underline for page limit
             watchCount.setPaintFlags(Paint.ANTI_ALIAS_FLAG | Paint.UNDERLINE_TEXT_FLAG);
         }
+        //prevent italic text from being cut off https://stackoverflow.com/a/61870394
+        watchCount.setShadowLayer(watchCount.getTextSize(), 0f, 0f, Color.TRANSPARENT);
     }
 
     private void loadBookmarkImage(PinViewHolder holder, Pin pin) {


### PR DESCRIPTION
![1595432493265](https://user-images.githubusercontent.com/40862101/88198801-c1400300-cc4c-11ea-8474-21006e485acb.jpg)

Seems to be an old issue, found several reports of this issue on stackoverflow (some dating back to 2010!):
https://stackoverflow.com/questions/4353836/italic-textview-with-wrap-contents-seems-to-clip-the-text-at-right-edge
https://stackoverflow.com/questions/10243374/textview-cutting-off-a-letter-in-android
https://stackoverflow.com/questions/44074858/android-textview-text-get-cut-off-on-the-sides-with-custom-font
etc.

tl;dr:

> This is because the wrap_contents creates a rectangle and the textview text tries to fit in but in italics some part in the starting or end is clipped because it is outside that rectangle made by wrap_content.

Source for fix: https://stackoverflow.com/a/61870394
