### PR TITLE
Fix filename randomizer clearing reply layout fields

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ReplyPresenter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/presenter/ReplyPresenter.java
@@ -392,6 +392,10 @@ public class ReplyPresenter
         callback.updateCommentCount(length, board.maxCommentChars, length > board.maxCommentChars);
     }
 
+    public void onTextChanged() {
+        callback.loadViewsIntoDraft(draft);
+    }
+
     public void onSelectionChanged() {
         callback.loadViewsIntoDraft(draft);
         highlightQuotes();
@@ -399,11 +403,7 @@ public class ReplyPresenter
 
     public boolean filenameNewClicked(boolean showToast) {
         String currentExt = StringUtils.extractFileNameExtension(draft.fileName);
-        if (currentExt == null) {
-            currentExt = "";
-        } else {
-            currentExt = "." + currentExt;
-        }
+        currentExt = (currentExt == null) ? "" : "." + currentExt;
         draft.fileName = System.currentTimeMillis() + currentExt;
         callback.loadDraftIntoViews(draft);
         if (showToast) {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/ReplyLayout.java
@@ -233,6 +233,10 @@ public class ReplyLayout
         commentEqnButton.setOnClickListener(this);
         commentSJISButton.setOnClickListener(this);
 
+        name.addTextChangedListener(this);
+        flag.addTextChangedListener(this);
+        options.addTextChangedListener(this);
+        subject.addTextChangedListener(this);
         comment.addTextChangedListener(this);
         comment.setSelectionChangedListener(this);
         comment.setOnFocusChangeListener((view, focused) -> {
@@ -520,14 +524,20 @@ public class ReplyLayout
             draft.comment = EmojiParser.parseToUnicode(draft.comment);
         }
 
-        name.setText(draft.name);
-        subject.setText(draft.subject);
-        flag.setText(draft.flag);
-        options.setText(draft.options);
+        if (!name.getText().toString().equals(draft.name))
+            name.setText(draft.name);
+        if (!subject.getText().toString().equals(draft.subject))
+            subject.setText(draft.subject);
+        if (!flag.getText().toString().equals(draft.flag))
+            flag.setText(draft.flag);
+        if (!options.getText().toString().equals(draft.options))
+            options.setText(draft.options);
         blockSelectionChange = true;
-        comment.setText(draft.comment);
+        if (!comment.getText().toString().equals(draft.comment))
+            comment.setText(draft.comment);
         blockSelectionChange = false;
-        fileName.setText(draft.fileName);
+        if (!fileName.getText().toString().equals(draft.fileName))
+            fileName.setText(draft.fileName);
         spoiler.setChecked(draft.spoilerImage);
     }
 
@@ -917,7 +927,12 @@ public class ReplyLayout
 
     @Override
     public void afterTextChanged(Editable s) {
-        presenter.onCommentTextChanged(comment.getText());
+        if (s.equals(comment.getText())) {
+            presenter.onCommentTextChanged(comment.getText());
+        }
+        else {
+            presenter.onTextChanged();
+        }
     }
 
     @Override


### PR DESCRIPTION
Randomizing the the filename clears the name, subject, flag and option fields in certain situations:

![exxx1](https://user-images.githubusercontent.com/40862101/88952253-d85fa000-d29f-11ea-8cc4-ad8d631fe970.gif)

The issue is that the aforementioned fields do not have a text change listener set to them, so changes made do not get saved to the reply draft unless the comment (which does have a listener) is edited after. If you edit the other fields without editing the comment and then randomize the filename, `loadDraftIntoViews` gets called which overwrites any text in the fields with whatever is saved in the draft (nothing in this case).
