### PR TITLE
Even more updates and cleanup

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -101,6 +101,7 @@ android {
 
     lintOptions {
         abortOnError false
+        disable 'UseSwitchCompatOrMaterialCode'
     }
 
     packagingOptions {

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -218,20 +218,24 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0-rc01'
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0-rc02'
     implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.drawerlayout:drawerlayout:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.2.0'
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'androidx.drawerlayout:drawerlayout:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.7'
+
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.11.7'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.11.7'
+    // Don't update to 4.8.0 - see https://github.com/Adamantcheese/Kuroba/issues/1016
+    //noinspection GradleDependency
     implementation 'com.squareup.okhttp3:okhttp:4.7.2'
     implementation 'com.j256.ormlite:ormlite-core:5.1'
     implementation 'com.j256.ormlite:ormlite-android:5.1'
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.20'
     implementation 'org.greenrobot:eventbus:3.2.0'
@@ -251,12 +255,12 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.8.0'
-    testImplementation 'org.mockito:mockito-core:3.3.3'
+    testImplementation 'org.mockito:mockito-core:3.4.6'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
 
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.3'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
 }
 
 // Download the current archives.json file for the build

--- a/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -17,7 +17,6 @@ import android.graphics.RectF;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Handler;
-import android.os.Message;
 import android.provider.MediaStore;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
@@ -341,16 +340,14 @@ public class SubsamplingScaleImageView
         setDoubleTapZoomDpi(160);
         setMinimumTileDpi(320);
         setGestureDetector(context);
-        this.handler = new Handler(new Handler.Callback() {
-            public boolean handleMessage(Message message) {
-                if (message.what == MESSAGE_LONG_CLICK && onLongClickListener != null) {
-                    maxTouchCount = 0;
-                    SubsamplingScaleImageView.super.setOnLongClickListener(onLongClickListener);
-                    performLongClick();
-                    SubsamplingScaleImageView.super.setOnLongClickListener(null);
-                }
-                return true;
+        this.handler = new Handler(message -> {
+            if (message.what == MESSAGE_LONG_CLICK && onLongClickListener != null) {
+                maxTouchCount = 0;
+                SubsamplingScaleImageView.super.setOnLongClickListener(onLongClickListener);
+                performLongClick();
+                SubsamplingScaleImageView.super.setOnLongClickListener(null);
             }
+            return true;
         });
         // Handle XML attributes
         if (attr != null) {
@@ -1147,6 +1144,7 @@ public class SubsamplingScaleImageView
                     for (Tile tile : tileMapEntry.getValue()) {
                         if (tile.visible && (tile.loading || tile.bitmap == null)) {
                             hasMissingTiles = true;
+                            break;
                         }
                     }
                 }
@@ -1359,6 +1357,7 @@ public class SubsamplingScaleImageView
                     for (Tile tile : tileMapEntry.getValue()) {
                         if (tile.loading || tile.bitmap == null) {
                             baseLayerReady = false;
+                            break;
                         }
                     }
                 }
@@ -1573,7 +1572,7 @@ public class SubsamplingScaleImageView
             // Choose the smallest ratio as inSampleSize value, this will guarantee
             // a final image with both dimensions larger than or equal to the
             // requested height and width.
-            inSampleSize = heightRatio < widthRatio ? heightRatio : widthRatio;
+            inSampleSize = Math.min(heightRatio, widthRatio);
         }
 
         // We want the actual sample size that will be used, so round down to nearest power of 2.
@@ -1736,7 +1735,7 @@ public class SubsamplingScaleImageView
         ) {
             this.viewRef = new WeakReference<>(view);
             this.contextRef = new WeakReference<>(context);
-            this.decoderFactoryRef = new WeakReference<DecoderFactory<? extends ImageRegionDecoder>>(decoderFactory);
+            this.decoderFactoryRef = new WeakReference<>(decoderFactory);
             this.source = source;
         }
 
@@ -1932,7 +1931,7 @@ public class SubsamplingScaleImageView
         ) {
             this.viewRef = new WeakReference<>(view);
             this.contextRef = new WeakReference<>(context);
-            this.decoderFactoryRef = new WeakReference<DecoderFactory<? extends ImageDecoder>>(decoderFactory);
+            this.decoderFactoryRef = new WeakReference<>(decoderFactory);
             this.source = source;
             this.preview = preview;
         }

--- a/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
+++ b/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
@@ -156,10 +156,6 @@ public class SkiaImageRegionDecoder implements ImageRegionDecoder {
      * use the write lock to enforce single threaded decoding.
      */
     private Lock getDecodeLock() {
-        if (Build.VERSION.SDK_INT < 21) {
-            return decoderLock.writeLock();
-        } else {
-            return decoderLock.readLock();
-        }
+        return decoderLock.readLock();
     }
 }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/gesture_editor/AdjustAndroid10GestureZonesView.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/gesture_editor/AdjustAndroid10GestureZonesView.kt
@@ -30,15 +30,15 @@ class AdjustAndroid10GestureZonesView @JvmOverloads constructor(
 
     private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.FILL
-        color = getRes().getColor(R.color.gestures_zone_view_background)
+        color = getRes().getColor(R.color.gestures_zone_view_background, null)
     }
     private val addedZonesPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.FILL
-        color = getRes().getColor(R.color.gestures_zone_view_added_zones)
+        color = getRes().getColor(R.color.gestures_zone_view_added_zones, null)
     }
     private val currentEditableZonePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.FILL
-        color = getRes().getColor(R.color.gestures_zone_view_current_zone)
+        color = getRes().getColor(R.color.gestures_zone_view_current_zone, null)
     }
     private val handlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.FILL

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/DrawerAdapter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/DrawerAdapter.java
@@ -16,7 +16,6 @@
  */
 package com.github.adamantcheese.chan.ui.adapter;
 
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Handler;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/AlbumDownloadController.java
@@ -54,7 +54,6 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
 import static com.github.adamantcheese.chan.Chan.inject;
-import static com.github.adamantcheese.chan.utils.AndroidUtils.dp;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getQuantityString;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getString;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.showToast;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/LoginController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/LoginController.java
@@ -122,7 +122,7 @@ public class LoginController
         if (loginResponse.success) {
             crossfadeView.toggle(false, true);
             button.setText(R.string.setting_pass_logout);
-            authenticated.setText(loginResponse.message);;
+            authenticated.setText(loginResponse.message);
         } else {
             authFail(loginResponse);
         }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/ThemeSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/ThemeSettingsController.java
@@ -121,7 +121,7 @@ public class ThemeSettingsController
         public Object onPopulatePostOptions(
                 Post post, List<FloatingMenuItem<Integer>> menu, List<FloatingMenuItem<Integer>> extraMenu
         ) {
-            menu.add(new FloatingMenuItem<Integer>(1, "Option"));
+            menu.add(new FloatingMenuItem<>(1, "Option"));
             return 0;
         }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/WatchSettingsController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/WatchSettingsController.java
@@ -132,11 +132,10 @@ public class WatchSettingsController
                 HOURS.toMillis(2)};
         //@formatter:on
 
-        //noinspection unchecked
         List<Item<Integer>> timeoutsItems = new ArrayList<>(timeouts.length);
-        for (int i = 0; i < timeouts.length; i++) {
-            String name = getString(R.string.minutes, (int) MILLISECONDS.toMinutes(timeouts[i]));
-            timeoutsItems.add(new Item<>(name, (int) timeouts[i]));
+        for (long timeout : timeouts) {
+            String name = getString(R.string.minutes, (int) MILLISECONDS.toMinutes(timeout));
+            timeoutsItems.add(new Item<>(name, (int) timeout));
         }
         backgroundTimeout = settings.add(new ListSettingView<Integer>(this,
                 ChanSettings.watchBackgroundInterval,

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/Theme.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/theme/Theme.java
@@ -26,8 +26,6 @@ import com.github.adamantcheese.chan.core.site.parser.PostParser;
 import com.github.adamantcheese.chan.utils.AndroidUtils;
 import com.github.adamantcheese.chan.utils.StringUtils;
 
-import static com.github.adamantcheese.chan.utils.AndroidUtils.getAttrColor;
-
 /**
  * A Theme object, a wrapper around a Android theme<br>
  * Used for setting the toolbar color, and passed around {@link PostParser} to give spans their correct colors.<br>

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/CustomScaleImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/CustomScaleImageView.java
@@ -17,7 +17,6 @@
 package com.github.adamantcheese.chan.ui.view;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.graphics.RectF;
 
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/IOUtils.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/utils/IOUtils.java
@@ -32,7 +32,7 @@ public class IOUtils {
     public static String assetAsString(Context context, String assetName) {
         String res = null;
         try {
-            res = IOUtils.readString(context.getResources().getAssets().open(assetName));
+            res = readString(context.getResources().getAssets().open(assetName));
         } catch (IOException ignored) {
         }
         return res;

--- a/Kuroba/app/src/main/res/layout/layout_post_replies.xml
+++ b/Kuroba/app/src/main/res/layout/layout_post_replies.xml
@@ -56,11 +56,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:drawableLeft="@drawable/ic_arrow_back_themed_24dp"
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
                     android:paddingRight="20dp"
-                    android:text="@string/back" />
+                    android:text="@string/back"
+                    app:drawableLeftCompat="@drawable/ic_arrow_back_themed_24dp" />
             </FrameLayout>
 
             <FrameLayout
@@ -77,11 +77,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:drawableLeft="@drawable/ic_done_themed_24dp"
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
                     android:paddingRight="20dp"
-                    android:text="@string/close" />
+                    android:text="@string/close"
+                    app:drawableLeftCompat="@drawable/ic_done_themed_24dp" />
             </FrameLayout>
         </LinearLayout>
 

--- a/Kuroba/app/src/main/res/layout/layout_post_replies_bottombuttons.xml
+++ b/Kuroba/app/src/main/res/layout/layout_post_replies_bottombuttons.xml
@@ -65,11 +65,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:drawableLeft="@drawable/ic_arrow_back_themed_24dp"
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
                     android:paddingRight="20dp"
-                    android:text="@string/back" />
+                    android:text="@string/back"
+                    app:drawableLeftCompat="@drawable/ic_arrow_back_themed_24dp" />
             </FrameLayout>
 
             <FrameLayout
@@ -86,11 +86,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:drawableLeft="@drawable/ic_done_themed_24dp"
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
                     android:paddingRight="20dp"
-                    android:text="@string/close" />
+                    android:text="@string/close"
+                    app:drawableLeftCompat="@drawable/ic_done_themed_24dp" />
             </FrameLayout>
         </LinearLayout>
 

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/CacheHandlerTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/CacheHandlerTest.kt
@@ -4,7 +4,6 @@ import com.github.adamantcheese.chan.core.cache.downloader.TestModule
 import com.github.adamantcheese.chan.utils.AndroidUtils
 import com.github.k1rakishou.fsaf.FileManager
 import com.github.k1rakishou.fsaf.file.RawFile
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.After
 import org.junit.Assert.assertFalse

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/ErrorMapperTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/ErrorMapperTest.kt
@@ -3,8 +3,8 @@ package com.github.adamantcheese.chan.core.cache
 import com.github.adamantcheese.chan.core.cache.downloader.ActiveDownloads
 import com.github.adamantcheese.chan.core.cache.downloader.FileCacheException
 import com.github.adamantcheese.chan.core.cache.downloader.FileDownloadResult
-import junit.framework.Assert.assertTrue
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ErrorMapperTest {

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkDownloaderTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkDownloaderTest.kt
@@ -8,7 +8,6 @@ import com.github.adamantcheese.chan.utils.AndroidUtils
 import com.github.k1rakishou.fsaf.FileManager
 import com.github.k1rakishou.fsaf.file.RawFile
 import io.reactivex.schedulers.Schedulers
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.junit.After

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkPersisterTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ChunkPersisterTest.kt
@@ -19,13 +19,11 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.internal.closeQuietly
-import org.apache.tools.ant.taskdefs.condition.Http
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.*
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowLog
@@ -167,7 +165,7 @@ class ChunkPersisterTest {
                 .groupBy { event -> event.chunkIndex }
 
         assertEquals(2, successEventsGrouped.values.count())
-        successEventsGrouped.forEach { (chunkIndex, chunkSuccessEvents) ->
+        successEventsGrouped.forEach { (_, chunkSuccessEvents) ->
             assertEquals(1, chunkSuccessEvents.size)
             val chunkSuccessEvent = chunkSuccessEvents.first()
 

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ConcurrentChunkedFileDownloaderTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/ConcurrentChunkedFileDownloaderTest.kt
@@ -69,7 +69,7 @@ class ConcurrentChunkedFileDownloaderTest {
                     .setResponseCode(200)
                     .setBody(buffer)
 
-            singleChunkTestProlog(server, response) { url, output, request, testObserver ->
+            singleChunkTestProlog(server, response) { _, output, request, testObserver ->
                 request.cancelableDownload.cancel()
 
                 val (events, errors, completes) = testObserver
@@ -99,7 +99,7 @@ class ConcurrentChunkedFileDownloaderTest {
         withServer { server ->
             val response = MockResponse().setResponseCode(404)
 
-            singleChunkTestProlog(server, response) { url, output, request, testObserver ->
+            singleChunkTestProlog(server, response) { _, output, _, testObserver ->
                 val (events, errors, completes) = testObserver
                         .awaitDone(MAX_AWAIT_TIME_SECONDS, TimeUnit.SECONDS)
                         .events
@@ -282,7 +282,7 @@ class ConcurrentChunkedFileDownloaderTest {
                     .setResponseCode(200)
                     .setBody(buffer)
 
-            singleChunkTestProlog(server, response) { url, output, request, testObserver ->
+            singleChunkTestProlog(server, response) { url, output, _, testObserver ->
                 val (events, errors, completes) = testObserver
                         .awaitDone(MAX_AWAIT_TIME_SECONDS, TimeUnit.SECONDS)
                         .events
@@ -314,7 +314,7 @@ class ConcurrentChunkedFileDownloaderTest {
                 stream.available()
             }
 
-            multiChunkTestPrologue(server, fileSize.toLong(), 4, imageName) { url, output, request, testObserver ->
+            multiChunkTestPrologue(server, fileSize.toLong(), 4, imageName) { url, output, _, testObserver ->
                 val (events, errors, completes) = testObserver
                         .awaitDone(MAX_AWAIT_TIME_SECONDS, TimeUnit.SECONDS)
                         .events

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/PartialContentSupportCheckerTest.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/PartialContentSupportCheckerTest.kt
@@ -5,7 +5,6 @@ import com.github.adamantcheese.chan.core.cache.createFileDownloadRequest
 import com.github.adamantcheese.chan.core.cache.withServer
 import com.github.adamantcheese.chan.utils.AndroidUtils
 import com.github.k1rakishou.fsaf.file.RawFile
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import org.junit.After

--- a/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/TestModule.kt
+++ b/Kuroba/app/src/test/java/com/github/adamantcheese/chan/core/cache/downloader/TestModule.kt
@@ -137,7 +137,6 @@ class TestModule {
                     provideFileManager(),
                     provideCacheDirFile(),
                     provideChunksCacheDirFile(),
-                    false,
                     Executors.newSingleThreadExecutor()
             )
         }

--- a/Kuroba/build.gradle
+++ b/Kuroba/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'de.undercouch:gradle-download-task:4.0.4'
+        classpath 'de.undercouch:gradle-download-task:4.1.1'
     }
 }
 


### PR DESCRIPTION
Hello again. It's the usual.

### 1st commit
- Update `de.undercouch:gradle-download-task` 4.0.4 -> 4.1.1 ([changelog](https://github.com/michel-kraemer/gradle-download-task/releases))
- Update AndroidX AppCompat 1.2.0-rc01 -> 1.2.0-rc02 ([changelog](https://developer.android.com/jetpack/androidx/releases/appcompat#1.2.0-rc02))
- Replace general usage exoplayer with the modules we actually use
- Update Mockito 3.3.3 -> 3.4.6 ([changelog](https://github.com/mockito/mockito/releases))
- Update LeakCanary 2.3 -> 2.4 ([changelog](https://square.github.io/leakcanary/changelog/#version-24-2020-06-10))
- Update `com.android.tools:desugar_jdk_libs` 1.0.9 -> 1.0.10 ([changelog](https://github.com/google/desugar_jdk_libs/blob/master/CHANGELOG.md)) (1.0.11's artifact hasn't been made yet for some reason, but whatever)

### 2nd commit
- As usual, miscellaneous cleanup around the project

### 3rd commit
- Fixes a few deprecations I found (the deprecated getColor already returns theme as null, so this doesn't actually change anything as far as I'm aware)
