### PR TITLE
Updated ExoPlayer to 2.12.0, other library updates

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -218,11 +218,11 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0-rc02'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.drawerlayout:drawerlayout:1.1.0'
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
+    implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
+    implementation 'androidx.exifinterface:exifinterface:1.3.0'
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
@@ -230,11 +230,11 @@ dependencies {
 
     implementation 'com.google.android.exoplayer:exoplayer-core:2.11.7'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.11.7'
-    implementation 'com.squareup.okhttp3:okhttp:4.8.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.j256.ormlite:ormlite-core:5.1'
     implementation 'com.j256.ormlite:ormlite-android:5.1'
     implementation 'org.jsoup:jsoup:1.13.1'
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.20'
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'org.nibor.autolink:autolink:0.10.0'
     implementation 'com.google.code.gson:gson:2.8.6'
@@ -246,7 +246,7 @@ dependencies {
     }
     implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.github.K1rakishou:Fuck-Storage-Access-Framework:v1.0-alpha42'
 
     testImplementation 'junit:junit:4.13'

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -228,8 +228,8 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.11.7'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.11.7'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.12.0'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.12.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.j256.ormlite:ormlite-core:5.1'
     implementation 'com.j256.ormlite:ormlite-android:5.1'

--- a/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -365,15 +365,14 @@ public class SubsamplingScaleImageView
                 }
             }
             if (typedAttr.hasValue(R.styleable.SubsamplingScaleImageView_panEnabled)) {
-                setPanEnabled(typedAttr.getBoolean(R.styleable.SubsamplingScaleImageView_panEnabled, true));
+                this.panEnabled = typedAttr.getBoolean(R.styleable.SubsamplingScaleImageView_panEnabled, true);
             }
             if (typedAttr.hasValue(R.styleable.SubsamplingScaleImageView_zoomEnabled)) {
-                setZoomEnabled(typedAttr.getBoolean(R.styleable.SubsamplingScaleImageView_zoomEnabled, true));
+                this.zoomEnabled = typedAttr.getBoolean(R.styleable.SubsamplingScaleImageView_zoomEnabled, true);
             }
             if (typedAttr.hasValue(R.styleable.SubsamplingScaleImageView_quickScaleEnabled)) {
-                setQuickScaleEnabled(typedAttr.getBoolean(R.styleable.SubsamplingScaleImageView_quickScaleEnabled,
-                        true
-                ));
+                this.quickScaleEnabled = typedAttr.getBoolean(R.styleable.SubsamplingScaleImageView_quickScaleEnabled,
+						true);
             }
             if (typedAttr.hasValue(R.styleable.SubsamplingScaleImageView_tileBackgroundColor)) {
                 setTileBackgroundColor(typedAttr.getColor(R.styleable.SubsamplingScaleImageView_tileBackgroundColor,
@@ -1003,7 +1002,7 @@ public class SubsamplingScaleImageView
                     float scaleX = getWidth() / (float) getSWidth();
                     float scaleY = getHeight() / (float) getSHeight();
                     setScaleAndCenter(getAppliedOrientation() % 180 == 0 ? scaleY : scaleX, getCenter());
-                    setOrientation((getAppliedOrientation() + 90) % 360);
+                    this.orientation = (getAppliedOrientation() + 90) % 360;
                 }
                 if (touchCount == 1) {
                     isZooming = false;
@@ -1331,7 +1330,7 @@ public class SubsamplingScaleImageView
     /**
      * Helper method for setting the values of a tile matrix array.
      */
-    private void setMatrixArray(
+    private static void setMatrixArray(
             float[] array, float f0, float f1, float f2, float f3, float f4, float f5, float f6, float f7
     ) {
         array[0] = f0;
@@ -2233,7 +2232,7 @@ public class SubsamplingScaleImageView
     /**
      * Pythagoras distance between two points.
      */
-    private float distance(float x0, float x1, float y0, float y1) {
+    private static float distance(float x0, float x1, float y0, float y1) {
         float x = x0 - x1;
         float y = y0 - y1;
         return (float) Math.sqrt(x * x + y * y);
@@ -2535,7 +2534,7 @@ public class SubsamplingScaleImageView
      * @param duration Anm duration
      * @return Current value
      */
-    private float easeOutQuad(long time, float from, float change, long duration) {
+    private static float easeOutQuad(long time, float from, float change, long duration) {
         float progress = (float) time / (float) duration;
         return -change * progress * (progress - 2) + from;
     }
@@ -2549,7 +2548,7 @@ public class SubsamplingScaleImageView
      * @param duration Anm duration
      * @return Current value
      */
-    private float easeInOutQuad(long time, float from, float change, long duration) {
+    private static float easeInOutQuad(long time, float from, float change, long duration) {
         float timeF = time / (duration / 2f);
         if (timeF < 1) {
             return (change / 2f * timeF * timeF) + from;
@@ -2733,7 +2732,7 @@ public class SubsamplingScaleImageView
     public final void setMinimumDpi(int dpi) {
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         float averageDpi = (metrics.xdpi + metrics.ydpi) / 2;
-        setMaxScale(averageDpi / dpi);
+        this.maxScale = averageDpi / dpi;
     }
 
     /**
@@ -2745,7 +2744,7 @@ public class SubsamplingScaleImageView
     public final void setMaximumDpi(int dpi) {
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         float averageDpi = (metrics.xdpi + metrics.ydpi) / 2;
-        setMinScale(averageDpi / dpi);
+        this.minScale = averageDpi / dpi;
     }
 
     /**
@@ -3031,7 +3030,7 @@ public class SubsamplingScaleImageView
     public final void setDoubleTapZoomDpi(int dpi) {
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         float averageDpi = (metrics.xdpi + metrics.ydpi) / 2;
-        setDoubleTapZoomScale(averageDpi / dpi);
+        this.doubleTapZoomScale = averageDpi / dpi;
     }
 
     /**
@@ -3436,7 +3435,7 @@ public class SubsamplingScaleImageView
         void onPreviewLoadError(Exception e);
 
         /**
-         * Indicates an error initiliasing the decoder when using a tiling, or when loading the full
+         * Indicates an error initialising the decoder when using a tiling, or when loading the full
          * size bitmap when tiling is disabled. This method cannot be relied upon; certain encoding
          * types of supported image formats can result in corrupt or blank images being loaded and
          * displayed with no detectable error.

--- a/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
+++ b/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaImageRegionDecoder.java
@@ -5,13 +5,17 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
-import android.graphics.*;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.BitmapRegionDecoder;
+import android.graphics.Point;
+import android.graphics.Rect;
 import android.net.Uri;
-import android.os.Build;
+import android.text.TextUtils;
+
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.text.TextUtils;
 
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
 

--- a/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaPooledImageRegionDecoder.java
+++ b/Kuroba/app/src/main/java/com/davemorrissey/labs/subscaleview/decoder/SkiaPooledImageRegionDecoder.java
@@ -442,7 +442,7 @@ public class SkiaPooledImageRegionDecoder
         }
     }
 
-    private void debug(String message) {
+    private static void debug(String message) {
         if (debug) {
             Log.d(TAG, message);
         }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/stream/WebmStreamingDataSource.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/stream/WebmStreamingDataSource.java
@@ -246,7 +246,12 @@ public class WebmStreamingDataSource
 
     private void detectLength()
             throws HttpDataSource.HttpDataSourceException {
-        this.fileLength = dataSource.open(new DataSpec(uri, 0, C.LENGTH_UNSET, null));
+        this.fileLength = dataSource.open(new DataSpec.Builder()
+                .setUri(uri)
+                .setPosition(0)
+                .setLength(C.LENGTH_UNSET)
+                .setKey(null)
+                .build());
 
         Logger.d(this, "detectLength: " + this.fileLength);
     }
@@ -324,7 +329,12 @@ public class WebmStreamingDataSource
             // our DataSpec was supposed to read, it's okay to assume we will read the entirety
             // of our missing ranges, and we won't need to seek inside them.
 
-            DataSpec dataSpec = new DataSpec(uri, range.getLower(), range.getUpper() - range.getLower() + 1, null);
+            DataSpec dataSpec = new DataSpec.Builder()
+                    .setUri(uri)
+                    .setPosition(range.getLower())
+                    .setLength(range.getUpper() - range.getLower() + 1)
+                    .setKey(null)
+                    .build();
 
             dataSource.open(dataSpec);
             httpActiveRange = range;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/stream/WebmStreamingSource.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/cache/stream/WebmStreamingSource.kt
@@ -13,8 +13,8 @@ import com.github.adamantcheese.chan.utils.Logger
 import com.github.k1rakishou.fsaf.FileManager
 import com.github.k1rakishou.fsaf.file.AbstractFile
 import com.github.k1rakishou.fsaf.file.RawFile
+import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.FileDataSource
 import io.reactivex.android.schedulers.AndroidSchedulers
 import java.io.IOException
@@ -60,8 +60,10 @@ class WebmStreamingSource(
 
                         // The webm file is already completely downloaded, just use it from the disk
                         callback.onMediaSourceReady(
-                                ProgressiveMediaSource.Factory(DataSource.Factory { fileCacheSource })
-                                        .createMediaSource(uri)
+                                ProgressiveMediaSource.Factory { fileCacheSource }
+                                        .createMediaSource(MediaItem.Builder()
+                                                .setUri(uri)
+                                                .build())
                         )
                     }
 
@@ -110,8 +112,10 @@ class WebmStreamingSource(
                     val fileUri = Uri.parse(destination.getFullPath())
 
                     weakCallback.get()?.onMediaSourceReady(
-                            ProgressiveMediaSource.Factory(DataSource.Factory { FileDataSource() })
-                                    .createMediaSource(fileUri)
+                            ProgressiveMediaSource.Factory { FileDataSource() }
+                                    .createMediaSource(MediaItem.Builder()
+                                            .setUri(fileUri)
+                                            .build())
                     )
                 }, { error ->
                     BackgroundUtils.ensureMainThread()
@@ -147,8 +151,10 @@ class WebmStreamingSource(
         }
 
         callback.onMediaSourceReady(
-                ProgressiveMediaSource.Factory(DataSource.Factory { fileCacheSource })
-                        .createMediaSource(uri)
+                ProgressiveMediaSource.Factory { fileCacheSource }
+                        .createMediaSource(MediaItem.Builder()
+                                .setUri(uri)
+                                .build())
         )
     }
 
@@ -157,8 +163,10 @@ class WebmStreamingSource(
         val fileUri = Uri.parse(rawFile.getFullPath())
 
         callback.onMediaSourceReady(
-                ProgressiveMediaSource.Factory(DataSource.Factory { FileDataSource() })
-                        .createMediaSource(fileUri)
+                ProgressiveMediaSource.Factory { FileDataSource() }
+                        .createMediaSource(MediaItem.Builder()
+                                .setUri(fileUri)
+                                .build())
         )
     }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/SettingsNotificationManager.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/SettingsNotificationManager.kt
@@ -3,7 +3,6 @@ package com.github.adamantcheese.chan.core.manager
 import android.annotation.SuppressLint
 import androidx.annotation.ColorInt
 import com.github.adamantcheese.chan.R
-import com.github.adamantcheese.chan.core.manager.SettingsNotificationManager.SettingNotification
 import org.greenrobot.eventbus.EventBus
 
 object SettingsNotificationManager {

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/SiteSetupController.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/SiteSetupController.java
@@ -34,8 +34,6 @@ import com.github.adamantcheese.chan.ui.settings.StringSettingView;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.inject.Inject;
-
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getQuantityString;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.getString;
 import static com.github.adamantcheese.chan.utils.LayoutUtils.inflate;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/base_directory/SaveLocationSetupDelegate.kt
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/controller/settings/base_directory/SaveLocationSetupDelegate.kt
@@ -30,30 +30,30 @@ class SaveLocationSetupDelegate(
     fun showUseSAFOrOldAPIForSaveLocationDialog() {
         BackgroundUtils.ensureMainThread()
 
-        callbacks.runWithWritePermissionsOrShowErrorToast(Runnable {
+        callbacks.runWithWritePermissionsOrShowErrorToast {
             AlertDialog.Builder(context)
-                    .setTitle(R.string.media_settings_use_saf_for_save_location_dialog_title)
-                    .setMessage(R.string.media_settings_use_saf_for_save_location_dialog_message)
-                    .setPositiveButton(R.string.media_settings_use_saf_dialog_positive_button_text) { _, _ ->
-                        presenter.onSaveLocationUseSAFClicked()
-                    }
-                    .setNeutralButton(R.string.reset) { _, _ ->
-                        presenter.resetSaveLocationBaseDir()
+                .setTitle(R.string.media_settings_use_saf_for_save_location_dialog_title)
+                .setMessage(R.string.media_settings_use_saf_for_save_location_dialog_message)
+                .setPositiveButton(R.string.media_settings_use_saf_dialog_positive_button_text) { _, _ ->
+                    presenter.onSaveLocationUseSAFClicked()
+                }
+                .setNeutralButton(R.string.reset) { _, _ ->
+                    presenter.resetSaveLocationBaseDir()
 
-                        val defaultBaseDirFile = File(ChanSettings.saveLocation.fileApiBaseDir.get())
-                        if (!defaultBaseDirFile.exists() && !defaultBaseDirFile.mkdirs()) {
-                            callbacks.onCouldNotCreateDefaultBaseDir(defaultBaseDirFile.absolutePath)
-                            return@setNeutralButton
-                        }
+                    val defaultBaseDirFile = File(ChanSettings.saveLocation.fileApiBaseDir.get())
+                    if (!defaultBaseDirFile.exists() && !defaultBaseDirFile.mkdirs()) {
+                        callbacks.onCouldNotCreateDefaultBaseDir(defaultBaseDirFile.absolutePath)
+                        return@setNeutralButton
+                    }
 
-                        callbacks.onFilesBaseDirectoryReset()
-                    }
-                    .setNegativeButton(R.string.media_settings_use_saf_dialog_negative_button_text) { _, _ ->
-                        onSaveLocationUseOldApiClicked()
-                    }
-                    .create()
-                    .show()
-        })
+                    callbacks.onFilesBaseDirectoryReset()
+                }
+                .setNegativeButton(R.string.media_settings_use_saf_dialog_negative_button_text) { _, _ ->
+                    onSaveLocationUseOldApiClicked()
+                }
+                .create()
+                .show()
+        }
     }
 
     /**
@@ -63,9 +63,8 @@ class SaveLocationSetupDelegate(
         BackgroundUtils.ensureMainThread()
 
         val saveLocationController = SaveLocationController(context,
-                SaveLocationController.SaveLocationControllerMode.ImageSaveLocation,
-                SaveLocationControllerCallback { dirPath -> presenter.onSaveLocationChosen(dirPath) }
-        )
+                SaveLocationController.SaveLocationControllerMode.ImageSaveLocation
+        ) { dirPath -> presenter.onSaveLocationChosen(dirPath) }
 
         callbacks.pushController(saveLocationController)
     }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
@@ -22,6 +22,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
@@ -749,7 +750,8 @@ public class MultiImageView
         if (isImage) {
             ((CustomScaleImageView) activeView).setTileBackgroundColor(backgroundColor);
         } else {
-            ((GifImageView) activeView).getDrawable().setColorFilter(backgroundColor, PorterDuff.Mode.DST_OVER);
+            ((GifImageView) activeView).getDrawable().setColorFilter(
+                    new PorterDuffColorFilter(backgroundColor, PorterDuff.Mode.DST_OVER));
         }
     }
 

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/view/MultiImageView.java
@@ -55,6 +55,7 @@ import com.github.adamantcheese.chan.utils.Logger;
 import com.github.adamantcheese.chan.utils.NetUtils;
 import com.github.adamantcheese.chan.utils.PostUtils;
 import com.github.k1rakishou.fsaf.file.RawFile;
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.audio.AudioListener;
@@ -531,7 +532,8 @@ public class MultiImageView
                                 ? Player.REPEAT_MODE_ALL
                                 : Player.REPEAT_MODE_OFF);
 
-                        exoPlayer.prepare(source);
+                        exoPlayer.setMediaSource(source);
+                        exoPlayer.prepare();
                         exoPlayer.setVolume(0f);
                         exoPlayer.addAudioListener(MultiImageView.this);
                         exoVideoView.setOnClickListener(null);
@@ -638,11 +640,15 @@ public class MultiImageView
             String userAgent = Util.getUserAgent(getAppContext(), NetModule.USER_AGENT);
             DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(getContext(), userAgent);
             ProgressiveMediaSource.Factory progressiveFactory = new ProgressiveMediaSource.Factory(dataSourceFactory);
-            MediaSource videoSource = progressiveFactory.createMediaSource(Uri.fromFile(file));
+            MediaSource videoSource = progressiveFactory.createMediaSource(
+                    new MediaItem.Builder()
+                            .setUri(Uri.fromFile(file))
+                            .build());
 
             exoPlayer.setRepeatMode(ChanSettings.videoAutoLoop.get() ? Player.REPEAT_MODE_ALL : Player.REPEAT_MODE_OFF);
 
-            exoPlayer.prepare(videoSource);
+            exoPlayer.setMediaSource(videoSource);
+            exoPlayer.prepare();
             exoPlayer.addAudioListener(this);
             exoVideoView.setOnClickListener(null);
             exoVideoView.setOnTouchListener((view, motionEvent) -> gestureDetector.onTouchEvent(motionEvent));

--- a/Kuroba/build.gradle
+++ b/Kuroba/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.4.10'
 
     repositories {
         google()

--- a/Kuroba/gradle.properties
+++ b/Kuroba/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
+kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
### 1st commit
- Updated AndroidX AppCompat 1.2.0-rc02 -> 1.2.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/appcompat))
- Updated AndroidX DrawerLayout 1.1.0 -> 1.1.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/drawerlayout))
- Updated AndroidX ExifInterface 1.2.0 -> 1.3.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/exifinterface))
- Updated OkHttp3 4.8.1 -> 4.9.0 ([changelog](https://square.github.io/okhttp/changelog/))
- Updated android-gif-drawable 1.2.20 -> 1.2.21 ([changelog](https://github.com/koral--/android-gif-drawable/releases))
- Remove JDK7 declaration, as we don't need it because of compileOptions
- Update Kotlin 1.4.0 -> 1.4.10 ([changelog](https://github.com/JetBrains/kotlin/releases/tag/v1.4.10))

### 2nd commit
- Fix a random deprecation

### 3rd commit
- Update ExoPlayer 2.11.7 -> 2.12.0 ([changelog](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md))

### 4th commit
- Set official Kotlin codestyle in gradle.properties (I'll let you reformat if you want)

### 5th commit
- Tiny misc cleanup

### 6th commit
- Fix uh oh stinky code in the subsampling-scale-image-view library
