### PR TITLE
Add /otaku/ to the hardcoded sushichan board list.

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/Sushichan.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/sites/Sushichan.java
@@ -84,6 +84,7 @@ public class Sushichan
                 Board.fromSiteNameCode(this, "enjoyable sounds", "tunes"),
                 Board.fromSiteNameCode(this, "arts & literature", "culture"),
                 Board.fromSiteNameCode(this, "technology", "silicon"),
+                Board.fromSiteNameCode(this, "Japan / Otaku / Anime", "otaku"),
                 Board.fromSiteNameCode(this, "site meta-discussion", "yakuza"),
                 Board.fromSiteNameCode(this, "internet death cult", "hell"),
                 Board.fromSiteNameCode(this, "dat ecchi & hentai goodness", "lewd")


### PR DESCRIPTION
This board was created on the site quite a few months ago but just never added I guess. I believe this one line is all it takes, let me know if it is not.