### PR TITLE
show all caps on the 4chan captcha input

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/CustomJsonLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/CustomJsonLayout.java
@@ -7,6 +7,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.InputFilter;
 import android.util.AttributeSet;
 import android.util.Base64;
 import android.view.KeyEvent;
@@ -78,6 +79,11 @@ public class CustomJsonLayout
         fg = findViewById(R.id.fg);
         slider = findViewById(R.id.slider);
         input = findViewById(R.id.captcha_input);
+        InputFilter[] editFilters = input.getFilters();
+        InputFilter[] newFilters = new InputFilter[editFilters.length + 1];
+        System.arraycopy(editFilters, 0, newFilters, 0, editFilters.length);
+        newFilters[editFilters.length] = new InputFilter.AllCaps();
+        input.setFilters(newFilters);
         input.setOnEditorActionListener((v, actionId, event) -> {
             if ((event != null && event.getKeyCode() == KeyEvent.KEYCODE_ENTER)
                     || actionId == EditorInfo.IME_ACTION_DONE) {


### PR DESCRIPTION
Solves the issue described in [#1386](https://github.com/Adamantcheese/Kuroba/issues/1386). Pretty simple fix, I just followed [this StackOverflow answer](https://stackoverflow.com/a/25571410). Tested using SwiftKey and Gboard on my Pixel 6 Pro running Android 12, and in both cases the text comes out capitalized and the captcha submits as expected. 