### PR TITLE
All caps filter for new 4chan captcha screen input

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/Chan4CustomJsonlayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/captcha/Chan4CustomJsonlayout.java
@@ -11,6 +11,7 @@ import android.graphics.*;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.InputFilter;
 import android.util.*;
 import android.view.KeyEvent;
 import android.view.View;
@@ -91,6 +92,11 @@ public class Chan4CustomJsonlayout
         fg = findViewById(R.id.fg);
         slider = findViewById(R.id.slider);
         input = findViewById(R.id.captcha_input);
+        InputFilter[] editFilters = input.getFilters();
+        InputFilter[] newFilters = new InputFilter[editFilters.length + 1];
+        System.arraycopy(editFilters, 0, newFilters, 0, editFilters.length);
+        newFilters[editFilters.length] = new InputFilter.AllCaps();
+        input.setFilters(newFilters);
         input.setOnEditorActionListener((v, actionId, event) -> {
             if ((event != null && event.getKeyCode() == KeyEvent.KEYCODE_ENTER)
                     && event.getAction() == KeyEvent.ACTION_DOWN || actionId == EditorInfo.IME_ACTION_DONE) {


### PR DESCRIPTION
Redoes https://github.com/Adamantcheese/Kuroba/commit/7947cbe3d89efd20a92d2c94b7f877cb45ad15bf and #1395 because I think the filename was changed and the app doesn't have the all caps filter on the new 4chan captcha page.
Once again tested on my Pixel 6 Pro with Swiftkey.