### PR TITLE
Add thumbnails for embedded YouTube links

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/embedders/YoutubeEmbedder.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/embedders/YoutubeEmbedder.java
@@ -164,14 +164,16 @@ public class YoutubeEmbedder
             return new EmbedResult(
                     title,
                     duration,
-                    new PostImage.Builder()
-                        .serverFilename(thumbnailDefaultUrl)
-                        .thumbnailUrl(HttpUrl.get(thumbnailDefaultUrl))
-                        .imageUrl(HttpUrl.get(thumbnailMaxResUrl))
-                        .filename(title)
-                        .extension("jpg")
-                        .isInlined()
-                        .build()
+                    thumbnailDefaultUrl != null ?
+                            new PostImage.Builder()
+                                    .serverFilename(thumbnailDefaultUrl)
+                                    .thumbnailUrl(HttpUrl.get(thumbnailDefaultUrl))
+                                    .imageUrl(HttpUrl.get(thumbnailMaxResUrl))
+                                    .filename(title)
+                                    .extension("jpg")
+                                    .isInlined()
+                                    .build()
+                            : null
             );
         }).chain(input -> {
             Matcher paramsMatcher = API_PARAMS.matcher(response.body().string());


### PR DESCRIPTION
Adds thumbnails for embedded YouTube links. Although the server name is either default.jpg or maxresdefault.jpg, I set the displayed/downloaded name to be [video title].jpg
Screenshot:
![image](https://user-images.githubusercontent.com/23278147/200986652-9ee5cf1b-842f-4225-94d2-f9dcc5149816.png)
