### PR TITLE
Add filter to allow prioritizing posts when sorting board index

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/database/DatabaseHideManager.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/database/DatabaseHideManager.java
@@ -67,6 +67,7 @@ public class DatabaseHideManager {
                                 true,
                                 false,
                                 false,
+                                false,
                                 hiddenPost.hideRepliesToThisPost,
                                 false
                         );
@@ -203,6 +204,7 @@ public class DatabaseHideManager {
                         parentPost.filterStub,
                         parentPost.filterRemove,
                         parentPost.filterWatch,
+                        parentPost.filterPrioritize,
                         true,
                         parentPost.filterSaved
                 );
@@ -222,6 +224,7 @@ public class DatabaseHideManager {
             boolean filterStub,
             boolean filterRemove,
             boolean filterWatch,
+            boolean filterPrioritize,
             boolean filterReplies,
             boolean filterSaved
     ) {
@@ -250,6 +253,7 @@ public class DatabaseHideManager {
                         filterStub,
                         filterRemove,
                         filterWatch,
+                        filterPrioritize,
                         filterReplies,
                         false,
                         filterSaved

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/FilterEngine.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/manager/FilterEngine.java
@@ -48,7 +48,8 @@ public class FilterEngine {
         HIDE,
         COLOR,
         REMOVE,
-        WATCH;
+        WATCH,
+        PRIORITIZE;
 
         public static String actionName(FilterAction action) {
             return StringUtils.caseAndSpace(action.name() + " post", null, true);

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/Post.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/model/Post.java
@@ -78,6 +78,8 @@ public class Post
 
     public final boolean filterWatch;
 
+    public final boolean filterPrioritize;
+
     public final boolean filterReplies;
 
     public final boolean filterOnlyOP;
@@ -151,6 +153,7 @@ public class Post
         filterStub = builder.filterStub;
         filterRemove = builder.filterRemove;
         filterWatch = builder.filterWatch;
+        filterPrioritize = builder.filterPrioritize;
         filterReplies = builder.filterReplies;
         filterOnlyOP = builder.filterOnlyOP;
         filterSaved = builder.filterSaved;
@@ -198,6 +201,7 @@ public class Post
                 && filterStub == post.filterStub
                 && filterRemove == post.filterRemove
                 && filterWatch == post.filterWatch
+                && filterPrioritize == post.filterPrioritize
                 && filterReplies == post.filterReplies
                 && filterOnlyOP == post.filterOnlyOP
                 && filterSaved == post.filterSaved
@@ -244,6 +248,7 @@ public class Post
                 filterStub,
                 filterRemove,
                 filterWatch,
+                filterPrioritize,
                 filterReplies,
                 filterOnlyOP,
                 filterSaved,
@@ -302,6 +307,7 @@ public class Post
                         filterStub,
                         filterRemove,
                         filterWatch,
+                        filterPrioritize,
                         filterReplies,
                         filterOnlyOP,
                         filterSaved
@@ -385,6 +391,7 @@ public class Post
         public boolean filterStub;
         public boolean filterRemove;
         public boolean filterWatch;
+        public boolean filterPrioritize;
         public boolean filterReplies;
         public boolean filterOnlyOP;
         public boolean filterSaved;
@@ -546,6 +553,7 @@ public class Post
                 boolean stub,
                 boolean remove,
                 boolean watch,
+                boolean prioritize,
                 boolean filterReplies,
                 boolean onlyOnOp,
                 boolean filterSaved
@@ -554,6 +562,7 @@ public class Post
             filterStub = filterStub | stub;
             filterRemove = filterRemove | remove;
             filterWatch = filterWatch | watch;
+            filterPrioritize = filterPrioritize | prioritize;
             this.filterReplies = this.filterReplies | filterReplies;
             filterOnlyOP = filterOnlyOP | onlyOnOp;
             this.filterSaved = this.filterSaved | filterSaved;
@@ -621,6 +630,7 @@ public class Post
                             filterStub,
                             filterRemove,
                             filterWatch,
+                            filterPrioritize,
                             filterReplies,
                             filterOnlyOP,
                             filterSaved

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/PostParser.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/site/parser/PostParser.java
@@ -227,19 +227,23 @@ public class PostParser {
                                 false,
                                 false,
                                 false,
+                                false,
                                 f.applyToReplies,
                                 f.onlyOnOP,
                                 f.applyToSaved
                         );
                         break;
                     case HIDE:
-                        post.filter(new int[]{0}, true, false, false, f.applyToReplies, f.onlyOnOP, false);
+                        post.filter(new int[]{0}, true, false, false, false, f.applyToReplies, f.onlyOnOP, false);
                         break;
                     case REMOVE:
-                        post.filter(new int[]{0}, false, true, false, f.applyToReplies, f.onlyOnOP, false);
+                        post.filter(new int[]{0}, false, true, false, false, f.applyToReplies, f.onlyOnOP, false);
                         break;
                     case WATCH:
-                        post.filter(new int[]{0}, false, false, true, false, true, false);
+                        post.filter(new int[]{0}, false, false, true, false, false, true, false);
+                        break;
+                    case PRIORITIZE:
+                        post.filter(new int[]{0}, false, false, false, true, false, true, false);
                         break;
                 }
             }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/PostsFilter.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/adapter/PostsFilter.java
@@ -84,6 +84,21 @@ public class PostsFilter {
         // Process order
         Collections.sort(posts, postsOrder.postComparator);
 
+        // Partition posts into posts to sort with priority and normal posts and then rebuild
+        List<Post> postsToSortToTop = new ArrayList<>();
+        List<Post> postsNotToSortToTop = new ArrayList<>();
+
+        for (Post post : posts) {
+            if (post.filterPrioritize) {
+                postsToSortToTop.add(post);
+            } else {
+                postsNotToSortToTop.add(post);
+            }
+        }
+        posts.clear();
+        posts.addAll(postsToSortToTop);
+        posts.addAll(postsNotToSortToTop);
+
         // Process search
         if (!TextUtils.isEmpty(query)) {
             boolean add;

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/FilterLayout.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/ui/layout/FilterLayout.java
@@ -18,6 +18,7 @@ package com.github.adamantcheese.chan.ui.layout;
 
 import static com.github.adamantcheese.chan.Chan.inject;
 import static com.github.adamantcheese.chan.core.manager.FilterEngine.FilterAction.COLOR;
+import static com.github.adamantcheese.chan.core.manager.FilterEngine.FilterAction.PRIORITIZE;
 import static com.github.adamantcheese.chan.core.manager.FilterEngine.FilterAction.WATCH;
 import static com.github.adamantcheese.chan.ui.widget.DefaultAlertDialog.getDefaultAlertBuilder;
 import static com.github.adamantcheese.chan.utils.AndroidUtils.*;
@@ -386,7 +387,7 @@ public class FilterLayout
             filter.color = 0xffff0000;
         }
         colorPreview.setBackgroundColor(filter.color);
-        if (filter.action != WATCH.ordinal()) {
+        if (filter.action != WATCH.ordinal() && filter.action != PRIORITIZE.ordinal()) {
             applyToReplies.setEnabled(true);
             onlyOnOP.setEnabled(true);
             onlyOnOP.setChecked(false);

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@ Actions do the following:<br>
 <b>Watch:</b> If you have the thread watcher enabled and background watching on, catalogs will be periodically checked
 based on your interval setting and any OP that matches the filter will be put into your bookmarks. Any catalogs loaded
 by the you navigating to them from the board select popup will also be checked.<br>
+<b>Prioritize:</b> Prioritize the post when sorting the board index and force it to be before non-prioritized posts.<br>
 <br>
 Enabled filters have priority from top to bottom in your list. Filter precedence for actions is as follows:<br>
 1) Capcode or sticky<br>


### PR DESCRIPTION
Adds a filter to make matched posts appear before non-matched posts in the board view.  
Some screenshots:  
![image](https://github.com/Adamantcheese/Kuroba/assets/23278147/da808a67-ef8c-499d-acdb-4c270f820279)
![image](https://github.com/Adamantcheese/Kuroba/assets/23278147/39e688b3-4b3a-497b-83c6-7152d203de0b)
