### PR TITLE
Closes #1447

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/net/NetUtilsClasses.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/core/net/NetUtilsClasses.java
@@ -374,6 +374,7 @@ public class NetUtilsClasses {
                     .request(request)
                     .body(new EmptyResponseBody())
                     .protocol(Protocol.HTTP_1_1)
+                    .message("Canceled")
                     .build();
             executed = true;
             return new Response.Builder()


### PR DESCRIPTION
previous commit 2d5f77b360de1a04ab68cdae107602242c0f25c0 was missing one more part of the builder, this should actually fix it and close #1413 / #1447 
Tested by closing and reopening the app a bunch of times and I don't see any crash anymore