### PR TITLE
Add correct link for dlsite rjcode embeds

### DIFF
--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/EmbedResult.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/EmbedResult.java
@@ -25,17 +25,29 @@ public class EmbedResult {
      */
     public List<PostImage> extraImages = new ArrayList<>();
 
+    /**
+     * An optional target link to use instead of the one in the post if provided.
+     */
+    public String customLink = null;
+
     @SuppressWarnings("unused")
     private EmbedResult() {} // for gson, don't use otherwise
 
     public EmbedResult(
             @NonNull String title, @Nullable String duration, @Nullable PostImage extraImage
     ) {
+        this(title, duration, extraImage, null);
+    }
+
+    public EmbedResult(
+            @NonNull String title, @Nullable String duration, @Nullable PostImage extraImage, @Nullable String customLink
+    ) {
         this.title = title;
         this.duration = duration;
         if (extraImage != null) {
             this.extraImages.add(extraImage);
         }
+        this.customLink = customLink;
     }
 
     public EmbedResult(

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/EmbeddingEngine.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/EmbeddingEngine.java
@@ -360,7 +360,7 @@ public class EmbeddingEngine
                         sp(ChanSettings.fontSize.get())
                 );
 
-                EmbedderLinkLinkable pl = new EmbedderLinkLinkable(theme, URL);
+                EmbedderLinkLinkable pl = new EmbedderLinkLinkable(theme, parseResult.customLink != null ? parseResult.customLink : URL);
                 return span(replacement, pl);
             }, true);
         }

--- a/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/embedders/impl/DlsiteEmbedder.java
+++ b/Kuroba/app/src/main/java/com/github/adamantcheese/chan/features/embedding/embedders/impl/DlsiteEmbedder.java
@@ -109,7 +109,8 @@ public class DlsiteEmbedder
                             .filename(imageFilename)
                             .extension(fileExtension)
                             .isInlined()
-                            .build()
+                            .build(),
+                    "https://www.dlsite.com/maniax-touch/work/=/product_id/" + serverFilename
             );
         };
     }


### PR DESCRIPTION
Allows embedders to use a target link different than the one in the post and then fixes something I mentioned in #1394 where RJ code embeds showed a "No applications were found to open this link" toast instead of linking to the correct place, now clicking on an rjcode embed correctly links to the dlsite product page